### PR TITLE
Leverage nvim-dap-go for test debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,9 @@ return {
 
 ### ⚙️ Configuration
 
-| Argument | Default value                                   | Description                       |
-| -------- | ----------------------------------------------- | --------------------------------- |
-| `args`   | `{ "-v", "-race", "-count=1", "-timeout=60s" }` | Arguments to pass into `go test`. |
 | Argument         | Default value                                   | Description                                         |
 | ---------------- | ----------------------------------------------- | --------------------------------------------------- |
-| `args`           | `{ "-v", "-race", "-count=1", "-timeout=60s" }` | Arguments to pass into `gotestsum`.                 |
+| `args`           | `{ "-v", "-race", "-count=1", "-timeout=60s" }` | Arguments to pass into `go test`.                   |
 | `dap_go_enabled` | `false`                                         | Leverage nvim-dap-go for debugging tests.           |
 | `dap_go_args`    | `{}`                                            | Arguments to pass into `require("dap-go").setup()`. |
 

--- a/lua/neotest-golang/init.lua
+++ b/lua/neotest-golang/init.lua
@@ -392,7 +392,7 @@ function M.get_dap_config(test_name)
   -- :help dap-configuration
   local dap_config = {
     type = "go",
-    name = "Neotest-golang Debugger",
+    name = "Neotest-golang",
     request = "launch",
     mode = "test",
     program = "${fileDirname}",

--- a/lua/neotest-golang/init.lua
+++ b/lua/neotest-golang/init.lua
@@ -363,7 +363,7 @@ function M.build_single_test_runspec(pos, strategy)
 
   -- set up for debugging of test
   if strategy == "dap" then
-    run_spec.strategy = M.get_dap_config(test_name, test_folder_absolute_path)
+    run_spec.strategy = M.get_dap_config(test_name)
     run_spec.context.skip = true -- do not attempt to parse test output
 
     -- nvim-dap and nvim-dap-go cwd
@@ -388,14 +388,14 @@ end
 
 ---@param test_name string
 ---@return table | nil
-function M.get_dap_config(test_name, test_folder_absolute_path)
+function M.get_dap_config(test_name)
   -- :help dap-configuration
   local dap_config = {
     type = "go",
     name = "Neotest-golang Debugger",
     request = "launch",
     mode = "test",
-    program = test_folder_absolute_path,
+    program = "${fileDirname}",
     args = { "-test.run", "^" .. test_name .. "$" },
   }
 


### PR DESCRIPTION
Blocked by https://github.com/leoluz/nvim-dap-go/pull/81

- Auto-setup nvim-dap-go and provide it with a `cwd` for successful `dlv` debugging of test in Go sub-project.
- Add configuration options for nvim-dap-go.
- Resets nvim-dap-go inbetween test debug sessions, so to avoid a "sticky" `cwd`.

Needs overall cleanup and refactoring to make the whole project more readable and testable... but that will come later.