### PR TITLE
Remove need for gotestsum

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,8 @@ neotest-go.
 
 - Test output is printed undesirably:
   [neotest#391](https://github.com/nvim-neotest/neotest/issues/391). This is
-  currently mitigated in neotest-golang by using `gotestsum`. Long-term, it
-  would be great to be able to use the intended behavior of neotest and just run
-  `go test`.
+  currently mitigated in neotest-golang by erasing the file written by neotest,
+  containing the test command output.
 
 Use my forks, or make the changes locally on your machine:
 
@@ -65,13 +64,6 @@ Use my forks, or make the changes locally on your machine:
   (PR filed).
 
 ## 🥸 Installation and configuration
-
-You need to have [`gotestsum`](https://github.com/gotestyourself/gotestsum) on
-your `$PATH`:
-
-```bash
-go install gotest.tools/gotestsum@latest
-```
 
 ### 💤 Lazy.nvim
 
@@ -96,9 +88,9 @@ return {
 
 ### ⚙️ Configuration
 
-| Argument | Default value                                   | Description                         |
-| -------- | ----------------------------------------------- | ----------------------------------- |
-| `args`   | `{ "-v", "-race", "-count=1", "-timeout=60s" }` | Arguments to pass into `gotestsum`. |
+| Argument | Default value                                   | Description                       |
+| -------- | ----------------------------------------------- | --------------------------------- |
+| `args`   | `{ "-v", "-race", "-count=1", "-timeout=60s" }` | Arguments to pass into `go test`. |
 
 Example:
 
@@ -141,7 +133,6 @@ return {
       {
         "fredrikaverpil/neotest-golang",
         branch = "main",
-        build = "go install gotest.tools/gotestsum@latest",
       },
     },
     opts = function(_, opts)


### PR DESCRIPTION
### Why this change?

Ideally, we won't need the `gotestsum` dependency.

### What was done?

- Replace the dependency on `gotestsum` by running `go test`.
- Erase the file, written by Neotest, which contains the stdout/stderr test command output, at the end of the test's JSON parsing. This file erasing was key to avoid getting JSON spewed into the test output panel, as described in https://github.com/nvim-neotest/neotest/issues/391.
- Remove mentioning of `gotestsum` from README.
- Changed various inline notes.
- Comment out printouts of non-JSON lines for now (will have to add a log file or similar later).

### Notes

- Gotestsum could be added back in as an optional test runner, as an alternative to `go test`. But I think most users are looking to use as few dependencies as possible. 🎉 
- At this point, I wish I had tests, so this is really a sign that I should add some.
- It would also be desirable to output a log file. I'm seeing a lot of non-JSON lines being emitted by `go test` which could be good to add as warnings to a log file.
