### PR TITLE
Improve test detection for monorepos

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,12 @@ return {
 
 ## ⚙️ Configuration
 
-| Argument         | Default value                                   | Description                                                                               |
-| ---------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `go_test_args`   | `{ "-v", "-race", "-count=1", "-timeout=60s" }` | Arguments to pass into `go test`.                                                         |
-| `dap_go_enabled` | `false`                                         | Leverage [leoluz/nvim-dap-go](https://github.com/leoluz/nvim-dap-go) for debugging tests. |
-| `dap_go_opts`    | `{}`                                            | Options to pass into `require("dap-go").setup()`.                                         |
+| Argument         | Default value                                   | Description                                                                                                                            |
+| ---------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `go_test_args`   | `{ "-v", "-race", "-count=1", "-timeout=60s" }` | Arguments to pass into `go test`.                                                                                                      |
+| `dap_go_enabled` | `false`                                         | Leverage [leoluz/nvim-dap-go](https://github.com/leoluz/nvim-dap-go) for debugging tests.                                              |
+| `dap_go_opts`    | `{}`                                            | Options to pass into `require("dap-go").setup()`.                                                                                      |
+| `search_depth`   | `32`                                            | Search depth used when searching for `go.mod` and `go.sum` in monorepos. Increase this value if you don't see your tests in monorepos. |
 
 ### Example configuration: custom `go test` arguments
 
@@ -111,8 +112,9 @@ require("neotest").setup({
 })
 ```
 
-Note that the example above writes a coverage file.
-You can use [andythigpen/nvim-coverage](https://github.com/andythigpen/nvim-coverage) to show the coverage in Neovim.
+Note that the example above writes a coverage file. You can use
+[andythigpen/nvim-coverage](https://github.com/andythigpen/nvim-coverage) to
+show the coverage in Neovim.
 
 ### Example configuration: debugging
 


### PR DESCRIPTION
### Why this change?

Currently, if the folder in which you start neovim doesn't contain a `go.mod`/`go.sum`, tests are not detected.

### What was done in this PR?

Search the folder tree for `go.mod`/`go.sum` files and if found, return the current working folder as the root of the project. This causes tests to be found in neotest.

### Notes

Currently, a max depth of 100 is default, which is on the larger side. This could be set lower, and be configurable.