### PR TITLE
Support directory (go package) execution

### DIFF
--- a/lua/neotest-golang/ast.lua
+++ b/lua/neotest-golang/ast.lua
@@ -2,7 +2,9 @@ local lib = require("neotest.lib")
 
 local M = {}
 
-function M.discover_positions(file_path)
+--- Detect test names in Go *._test.go files.
+--- @param file_path string
+function M.detect_tests(file_path)
   local functions_and_methods = [[
     ;;query
     ((function_declaration

--- a/lua/neotest-golang/convert.lua
+++ b/lua/neotest-golang/convert.lua
@@ -52,4 +52,45 @@ function M.to_neotest_test_name_pattern(go_test_name)
   return test_name
 end
 
+function M.to_lua_pattern(str)
+  -- Escape characters, for usage of string as pattern.
+  -- - `.` (matches any character)
+  -- - `%` (used to escape special characters)
+  -- - `+` (matches 1 or more of the previous character or class)
+  -- - `*` (matches 0 or more of the previous character or class)
+  -- - `-` (matches 0 or more of the previous character or class, in the shortest sequence)
+  -- - `?` (makes the previous character or class optional)
+  -- - `^` (at the start of a pattern, matches the start of the string; in a character class `[]`, negates the class)
+  -- - `$` (matches the end of the string)
+  -- - `[]` (defines a character class)
+  -- - `()` (defines a capture)
+  -- - `:` (used in certain pattern items like `%b()`)
+  -- - `=` (used in certain pattern items like `%b()`)
+  -- - `<` (used in certain pattern items like `%b<>`)
+  -- - `>` (used in certain pattern items like `%b<>`)
+
+  local special_characters = {
+    ".",
+    "%",
+    "+",
+    "*",
+    "-",
+    "?",
+    "^",
+    "$",
+    "[",
+    "]",
+    "(",
+    ")",
+    ":",
+    "=",
+    "<",
+    ">",
+  }
+  for _, character in ipairs(special_characters) do
+    str = str:gsub("%" .. character, "%%%" .. character)
+  end
+  return str
+end
+
 return M

--- a/lua/neotest-golang/convert.lua
+++ b/lua/neotest-golang/convert.lua
@@ -22,6 +22,8 @@ end
 -- Converts the `go test` command test name into Neotest node test name format.
 -- Note that a pattern can returned, not the exact test name, so to support
 -- escaped quotes etc.
+-- NOTE: double quotes must be removed from the string matching against.
+
 ---@param go_test_name string
 ---@return string
 function M.to_neotest_test_name_pattern(go_test_name)
@@ -32,13 +34,20 @@ function M.to_neotest_test_name_pattern(go_test_name)
   -- Replace / with ::
   test_name = test_name:gsub("/", "::")
 
-  -- NOTE: double quotes are removed from the string we match against.
-
   -- Replace _ with space
   test_name = test_name:gsub("_", " ")
 
   -- Mark the end of the test name pattern
   test_name = test_name .. "$"
+
+  -- Percentage sign must be escaped
+  test_name = test_name:gsub("%%", "%%%%")
+
+  -- Literal brackets and parantheses must be escaped
+  test_name = test_name:gsub("%[", "%%[")
+  test_name = test_name:gsub("%]", "%%]")
+  test_name = test_name:gsub("%(", "%%(")
+  test_name = test_name:gsub("%)", "%%)")
 
   return test_name
 end

--- a/lua/neotest-golang/convert.lua
+++ b/lua/neotest-golang/convert.lua
@@ -1,6 +1,7 @@
 local M = {}
 
--- Converts the AST-detected test name into the 'go test' command test name format.
+-- Converts the AST-detected Neotest node test name into the 'go test' command
+-- test name format.
 ---@param pos_id string
 ---@return string
 function M.to_gotest_test_name(pos_id)
@@ -14,6 +15,30 @@ function M.to_gotest_test_name(pos_id)
   test_name = test_name:gsub('"', "")
   -- Replace any spaces with _
   test_name = test_name:gsub(" ", "_")
+
+  return test_name
+end
+
+-- Converts the `go test` command test name into Neotest node test name format.
+-- Note that a pattern can returned, not the exact test name, so to support
+-- escaped quotes etc.
+---@param go_test_name string
+---@return string
+function M.to_neotest_test_name_pattern(go_test_name)
+  -- construct the test name
+  local test_name = go_test_name
+  -- Add :: before the test name
+  test_name = "::" .. test_name
+  -- Replace / with ::
+  test_name = test_name:gsub("/", "::")
+
+  -- NOTE: double quotes are removed from the string we match against.
+
+  -- Replace _ with space
+  test_name = test_name:gsub("_", " ")
+
+  -- Mark the end of the test name pattern
+  test_name = test_name .. "$"
 
   return test_name
 end

--- a/lua/neotest-golang/convert.lua
+++ b/lua/neotest-golang/convert.lua
@@ -19,56 +19,23 @@ function M.to_gotest_test_name(pos_id)
   return test_name
 end
 
--- Converts the `go test` command test name into Neotest node test name format.
--- Note that a pattern can returned, not the exact test name, so to support
--- escaped quotes etc.
--- NOTE: double quotes must be removed from the string matching against.
-
----@param go_test_name string
----@return string
-function M.to_neotest_test_name_pattern(go_test_name)
-  -- construct the test name
-  local test_name = go_test_name
-  -- Add :: before the test name
-  test_name = "::" .. test_name
-  -- Replace / with ::
-  test_name = test_name:gsub("/", "::")
-
-  -- Replace _ with space
-  test_name = test_name:gsub("_", " ")
-
-  -- Mark the end of the test name pattern
-  test_name = test_name .. "$"
-
-  -- Percentage sign must be escaped
-  test_name = test_name:gsub("%%", "%%%%")
-
-  -- Literal brackets and parantheses must be escaped
-  test_name = test_name:gsub("%[", "%%[")
-  test_name = test_name:gsub("%]", "%%]")
-  test_name = test_name:gsub("%(", "%%(")
-  test_name = test_name:gsub("%)", "%%)")
-
-  return test_name
-end
-
+--- Escape characters, for usage of string as pattern in Lua..
+--- - `.` (matches any character)
+--- - `%` (used to escape special characters)
+--- - `+` (matches 1 or more of the previous character or class)
+--- - `*` (matches 0 or more of the previous character or class)
+--- - `-` (matches 0 or more of the previous character or class, in the shortest sequence)
+--- - `?` (makes the previous character or class optional)
+--- - `^` (at the start of a pattern, matches the start of the string; in a character class `[]`, negates the class)
+--- - `$` (matches the end of the string)
+--- - `[]` (defines a character class)
+--- - `()` (defines a capture)
+--- - `:` (used in certain pattern items like `%b()`)
+--- - `=` (used in certain pattern items like `%b()`)
+--- - `<` (used in certain pattern items like `%b<>`)
+--- - `>` (used in certain pattern items like `%b<>`)
+--- @param str string
 function M.to_lua_pattern(str)
-  -- Escape characters, for usage of string as pattern.
-  -- - `.` (matches any character)
-  -- - `%` (used to escape special characters)
-  -- - `+` (matches 1 or more of the previous character or class)
-  -- - `*` (matches 0 or more of the previous character or class)
-  -- - `-` (matches 0 or more of the previous character or class, in the shortest sequence)
-  -- - `?` (makes the previous character or class optional)
-  -- - `^` (at the start of a pattern, matches the start of the string; in a character class `[]`, negates the class)
-  -- - `$` (matches the end of the string)
-  -- - `[]` (defines a character class)
-  -- - `()` (defines a capture)
-  -- - `:` (used in certain pattern items like `%b()`)
-  -- - `=` (used in certain pattern items like `%b()`)
-  -- - `<` (used in certain pattern items like `%b<>`)
-  -- - `>` (used in certain pattern items like `%b<>`)
-
   local special_characters = {
     ".",
     "%",

--- a/lua/neotest-golang/discover_positions.lua
+++ b/lua/neotest-golang/discover_positions.lua
@@ -1,0 +1,100 @@
+local lib = require("neotest.lib")
+
+local M = {}
+
+function M.discover_positions(file_path)
+  local functions_and_methods = [[
+    ;;query
+    ((function_declaration
+      name: (identifier) @test.name)
+      (#match? @test.name "^(Test|Example)"))
+      @test.definition
+
+    (method_declaration
+      name: (field_identifier) @test.name
+      (#match? @test.name "^(Test|Example)")) @test.definition
+
+    (call_expression
+      function: (selector_expression
+        field: (field_identifier) @test.method)
+        (#match? @test.method "^Run$")
+      arguments: (argument_list . (interpreted_string_literal) @test.name))
+      @test.definition
+  ]]
+
+  local table_tests = [[
+    ;; query for list table tests
+        (block
+          (short_var_declaration
+            left: (expression_list
+              (identifier) @test.cases)
+            right: (expression_list
+              (composite_literal
+                (literal_value
+                  (literal_element
+                    (literal_value
+                      (keyed_element
+                        (literal_element
+                          (identifier) @test.field.name)
+                        (literal_element
+                          (interpreted_string_literal) @test.name)))) @test.definition))))
+          (for_statement
+            (range_clause
+              left: (expression_list
+                (identifier) @test.case)
+              right: (identifier) @test.cases1
+                (#eq? @test.cases @test.cases1))
+            body: (block
+             (expression_statement
+              (call_expression
+                function: (selector_expression
+                  field: (field_identifier) @test.method)
+                  (#match? @test.method "^Run$")
+                arguments: (argument_list
+                  (selector_expression
+                    operand: (identifier) @test.case1
+                    (#eq? @test.case @test.case1)
+                    field: (field_identifier) @test.field.name1
+                    (#eq? @test.field.name @test.field.name1))))))))
+
+    ;; query for map table tests 
+      (block
+          (short_var_declaration
+            left: (expression_list
+              (identifier) @test.cases)
+            right: (expression_list
+              (composite_literal
+                (literal_value
+                  (keyed_element
+                  (literal_element
+                      (interpreted_string_literal)  @test.name)
+                    (literal_element
+                      (literal_value)  @test.definition))))))
+        (for_statement
+           (range_clause
+              left: (expression_list
+                ((identifier) @test.key.name)
+                ((identifier) @test.case))
+              right: (identifier) @test.cases1
+                (#eq? @test.cases @test.cases1))
+            body: (block
+               (expression_statement
+                (call_expression
+                  function: (selector_expression
+                    field: (field_identifier) @test.method)
+                    (#match? @test.method "^Run$")
+                    arguments: (argument_list
+                    ((identifier) @test.key.name1
+                    (#eq? @test.key.name @test.key.name1))))))))
+  ]]
+
+  local query = functions_and_methods .. table_tests
+  local opts = { nested_tests = true }
+
+  ---@type neotest.Tree
+  local positions = lib.treesitter.parse_positions(file_path, query, opts)
+
+  return positions
+end
+
+return M

--- a/lua/neotest-golang/init.lua
+++ b/lua/neotest-golang/init.lua
@@ -11,30 +11,30 @@ local utils = require("neotest-golang.utils")
 
 local M = {}
 
----See neotest.Adapter for the full interface.
----@class Adapter : neotest.Adapter
----@field name string
+--- See neotest.Adapter for the full interface.
+--- @class Adapter : neotest.Adapter
+--- @field name string
 M.Adapter = {
   name = "neotest-golang",
 }
 
----Find the project root directory given a current directory to work from.
----Should no root be found, the adapter can still be used in a non-project context if a test file matches.
----@async
----@param dir string @Directory to treat as cwd
----@return string | nil @Absolute root dir of test suite
+--- Find the project root directory given a current directory to work from.
+--- Should no root be found, the adapter can still be used in a non-project context if a test file matches.
+--- @async
+--- @param dir string @Directory to treat as cwd
+--- @return string | nil @Absolute root dir of test suite
 function M.Adapter.root(dir)
   -- Since neotest-golang is setting the cwd prior to running tests or debugging
   -- we can use the cwd as-is and treat it as the root.
   return dir
 end
 
----Filter directories when searching for test files
----@async
----@param name string Name of directory
----@param rel_path string Path to directory, relative to root
----@param root string Root directory of project
----@return boolean
+--- Filter directories when searching for test files
+--- @async
+--- @param name string Name of directory
+--- @param rel_path string Path to directory, relative to root
+--- @param root string Root directory of project
+--- @return boolean
 function M.Adapter.filter_dir(name, rel_path, root)
   local ignore_dirs = { ".git", "node_modules", ".venv", "venv" }
   for _, ignore in ipairs(ignore_dirs) do
@@ -45,17 +45,17 @@ function M.Adapter.filter_dir(name, rel_path, root)
   return true
 end
 
----@async
----@param file_path string
----@return boolean
+--- @async
+--- @param file_path string
+--- @return boolean
 function M.Adapter.is_test_file(file_path)
   return vim.endswith(file_path, "_test.go")
 end
 
----Given a file path, parse all the tests within it.
----@async
----@param file_path string Absolute file path
----@return neotest.Tree | nil
+--- Given a file path, parse all the tests within it.
+--- @async
+--- @param file_path string Absolute file path
+--- @return neotest.Tree | nil
 function M.Adapter.discover_positions(file_path)
   return ast.detect_tests(file_path)
 end
@@ -64,12 +64,12 @@ end
 ---NOTE: right now, this test function is delegating any test execution on
 ---a per-test basis.
 ---
----@param args neotest.RunArgs
----@return nil | neotest.RunSpec | neotest.RunSpec[]
+--- @param args neotest.RunArgs
+--- @return nil | neotest.RunSpec | neotest.RunSpec[]
 function M.Adapter.build_spec(args)
-  ---@type neotest.Tree
+  --- @type neotest.Tree
   local tree = args.tree
-  ---@type neotest.Position
+  --- @type neotest.Position
   local pos = args.tree:data()
 
   if not tree then
@@ -116,13 +116,13 @@ function M.Adapter.build_spec(args)
   end
 end
 
----Parse the test execution results, populate test outcome into the neotest
----node tree.
----@async
----@param spec neotest.RunSpec
----@param result neotest.StrategyResult
----@param tree neotest.Tree
----@return table<string, neotest.Result>
+--- Parse the test execution results, populate test outcome into the neotest
+--- node tree.
+--- @async
+--- @param spec neotest.RunSpec
+--- @param result neotest.StrategyResult
+--- @param tree neotest.Tree
+--- @return table<string, neotest.Result>
 function M.Adapter.results(spec, result, tree)
   if spec.context.test_type == "dir" then
     return results_dir.results(spec, result, tree)

--- a/lua/neotest-golang/init.lua
+++ b/lua/neotest-golang/init.lua
@@ -1,13 +1,17 @@
-local lib = require("neotest.lib")
-local async = require("neotest.async")
-
-local convert = require("neotest-golang.convert")
+local options = require("neotest-golang.options")
+local discover_positions = require("neotest-golang.discover_positions")
+local runspec_test = require("neotest-golang.runspec_test")
+local results_test = require("neotest-golang.results_test")
+local utils = require("neotest-golang.utils")
 
 local M = {}
 
----@class neotest.Adapter
+---See neotest.Adapter for the full interface.
+---@class Adapter : neotest.Adapter
 ---@field name string
-M.Adapter = { name = "neotest-golang" }
+M.Adapter = {
+  name = "neotest-golang",
+}
 
 ---Find the project root directory given a current directory to work from.
 ---Should no root be found, the adapter can still be used in a non-project context if a test file matches.
@@ -40,7 +44,6 @@ end
 ---@param file_path string
 ---@return boolean
 function M.Adapter.is_test_file(file_path)
-  ---@type boolean
   return vim.endswith(file_path, "_test.go")
 end
 
@@ -49,100 +52,13 @@ end
 ---@param file_path string Absolute file path
 ---@return neotest.Tree | nil
 function M.Adapter.discover_positions(file_path)
-  local functions_and_methods = [[
-    ;;query
-    ((function_declaration
-      name: (identifier) @test.name)
-      (#match? @test.name "^(Test|Example)"))
-      @test.definition
-
-    (method_declaration
-      name: (field_identifier) @test.name
-      (#match? @test.name "^(Test|Example)")) @test.definition
-
-    (call_expression
-      function: (selector_expression
-        field: (field_identifier) @test.method)
-        (#match? @test.method "^Run$")
-      arguments: (argument_list . (interpreted_string_literal) @test.name))
-      @test.definition
-  ]]
-
-  local table_tests = [[
-    ;; query for list table tests
-        (block
-          (short_var_declaration
-            left: (expression_list
-              (identifier) @test.cases)
-            right: (expression_list
-              (composite_literal
-                (literal_value
-                  (literal_element
-                    (literal_value
-                      (keyed_element
-                        (literal_element
-                          (identifier) @test.field.name)
-                        (literal_element
-                          (interpreted_string_literal) @test.name)))) @test.definition))))
-          (for_statement
-            (range_clause
-              left: (expression_list
-                (identifier) @test.case)
-              right: (identifier) @test.cases1
-                (#eq? @test.cases @test.cases1))
-            body: (block
-             (expression_statement
-              (call_expression
-                function: (selector_expression
-                  field: (field_identifier) @test.method)
-                  (#match? @test.method "^Run$")
-                arguments: (argument_list
-                  (selector_expression
-                    operand: (identifier) @test.case1
-                    (#eq? @test.case @test.case1)
-                    field: (field_identifier) @test.field.name1
-                    (#eq? @test.field.name @test.field.name1))))))))
-
-    ;; query for map table tests 
-      (block
-          (short_var_declaration
-            left: (expression_list
-              (identifier) @test.cases)
-            right: (expression_list
-              (composite_literal
-                (literal_value
-                  (keyed_element
-                  (literal_element
-                      (interpreted_string_literal)  @test.name)
-                    (literal_element
-                      (literal_value)  @test.definition))))))
-        (for_statement
-           (range_clause
-              left: (expression_list
-                ((identifier) @test.key.name)
-                ((identifier) @test.case))
-              right: (identifier) @test.cases1
-                (#eq? @test.cases @test.cases1))
-            body: (block
-               (expression_statement
-                (call_expression
-                  function: (selector_expression
-                    field: (field_identifier) @test.method)
-                    (#match? @test.method "^Run$")
-                    arguments: (argument_list
-                    ((identifier) @test.key.name1
-                    (#eq? @test.key.name @test.key.name1))))))))
-  ]]
-
-  local query = functions_and_methods .. table_tests
-  local opts = { nested_tests = true }
-
-  ---@type neotest.Tree
-  local positions = lib.treesitter.parse_positions(file_path, query, opts)
-
-  return positions
+  return discover_positions.discover_positions(file_path)
 end
 
+---Build the runspec, which describes how to execute the test(s).
+---NOTE: right now, this test function is delegating any test execution on
+---a per-test basis.
+---
 ---@param args neotest.RunArgs
 ---@return nil | neotest.RunSpec | neotest.RunSpec[]
 function M.Adapter.build_spec(args)
@@ -152,7 +68,7 @@ function M.Adapter.build_spec(args)
   local pos = args.tree:data()
 
   if not tree then
-    vim.notify("NOT A TREE!")
+    vim.notify("Error: [build_spec] not a tree!", vim.log.levels.ERROR)
     return
   end
 
@@ -160,31 +76,14 @@ function M.Adapter.build_spec(args)
     -- Test suite
 
     return -- delegate test execution to per-test execution
-
-    -- NOTE: could potentially run 'go test' on the whole directory, to make
-    -- tests go a lot faster, but would come with the added complexity of
-    -- having to traverse the node tree manually and set statuses accordingly.
-    -- I'm not sure it's worth it...
   elseif pos.type == "dir" then
     -- Sub-directory
 
     return -- delegate test execution to per-test execution
-
-    -- NOTE: could potentially run 'go test' on the whole file, to make
-    -- tests go a lot faster, but would come with the added complexity of
-    -- having to traverse the node tree manually and set statuses accordingly.
-    -- I'm not sure it's worth it...
-    --
-    -- ---@type string
-    -- local relative_test_folderpath = vim.fn.fnamemodify(pos.path, ":~:.")
-    -- ---@type string
-    -- local relative_test_folderpath_go = "./"
-    --   .. relative_test_folderpath
-    --   .. "/..."
   elseif pos.type == "file" then
     -- Single file
 
-    if M.table_is_empty(tree:children()) then
+    if utils.table_is_empty(tree:children()) then
       -- No tests present in file
       ---@type neotest.RunSpec
       local run_spec = {
@@ -192,6 +91,7 @@ function M.Adapter.build_spec(args)
         context = {
           id = pos.id,
           skip = true,
+          test_type = "test", -- TODO: to be implemented as "file" later
         },
       }
       return run_spec
@@ -206,216 +106,23 @@ function M.Adapter.build_spec(args)
     end
   elseif pos.type == "test" then
     -- Single test
-    return M.build_single_test_runspec(pos, args.strategy)
+    return runspec_test.build(pos, args.strategy)
   else
-    vim.notify("ERROR: WHAT IS THIS ???: " .. pos.type)
+    vim.notify("Error: [build_spec] unknown position type: " .. pos.type)
     return
   end
 end
 
+---Parse the test execution results, populate test outcome into the neotest
+---node tree.
 ---@async
 ---@param spec neotest.RunSpec
 ---@param result neotest.StrategyResult
 ---@param tree neotest.Tree
 ---@return table<string, neotest.Result>
 function M.Adapter.results(spec, result, tree)
-  if spec.context.skip then
-    ---@type table<string, neotest.Result>
-    local results = {}
-    results[spec.context.id] = {
-      ---@type neotest.ResultStatus
-      status = "skipped",
-    }
-    return results
-  end
-
-  ---@type neotest.ResultStatus
-  local result_status = "skipped"
-  if result.code == 0 then
-    result_status = "passed"
-  else
-    result_status = "failed"
-  end
-
-  ---@type table
-  local raw_output = async.fn.readfile(result.output)
-
-  ---@type string
-  local test_filepath = spec.context.test_filepath
-  local test_filename = vim.fn.fnamemodify(test_filepath, ":t")
-  ---@type List
-  local test_result = {}
-  ---@type neotest.Error[]
-  local errors = {}
-  ---@type List<table>
-  local jsonlines = M.process_json(raw_output)
-
-  for _, line in ipairs(jsonlines) do
-    if line.Action == "output" and line.Output ~= nil then
-      -- record output, prints to output panel
-      table.insert(test_result, line.Output)
-    end
-
-    if result.code ~= 0 and line.Output ~= nil then
-      -- record an error
-      ---@type string
-      local matched_line_number =
-        string.match(line.Output, test_filename .. ":(%d+):")
-
-      if matched_line_number ~= nil then
-        -- attempt to parse the line number...
-        ---@type number | nil
-        local line_number = tonumber(matched_line_number)
-
-        if line_number ~= nil then
-          -- log the error along with its line number (for diagnostics)
-
-          ---@type string
-          local message = string.match(line.Output, ":%d+: (.*)")
-
-          ---@type neotest.Error
-          local error = {
-            message = message,
-            line = line_number - 1, -- neovim lines are 0-indexed
-          }
-          table.insert(errors, error)
-        end
-      end
-    end
-  end
-
-  -- write json_decoded to file
-  local parsed_output_path = vim.fs.normalize(async.fn.tempname())
-  async.fn.writefile(test_result, parsed_output_path)
-
-  ---@type table<string, neotest.Result>
-  local results = {}
-  results[spec.context.id] = {
-    status = result_status,
-    output = parsed_output_path,
-    errors = errors,
-  }
-
-  -- FIXME: once output is parsed, erase file contents, so to avoid JSON in
-  -- output panel. This is a workaround for now, only because of
-  -- https://github.com/nvim-neotest/neotest/issues/391
-  vim.fn.writefile({ "" }, result.output)
-
-  return results
+  return results_test.results_test(spec, result, tree)
 end
-
---- Build runspec for a single test
----@param pos neotest.Position
----@param strategy string
----@return neotest.RunSpec
-function M.build_single_test_runspec(pos, strategy)
-  ---@type string
-  local test_name = convert.to_gotest_test_name(pos.id)
-  ---@type string
-  local test_folder_absolute_path = string.match(pos.path, "(.+)/")
-
-  local gotest = {
-    "go",
-    "test",
-    "-json",
-  }
-
-  ---@type table
-  local go_test_args = {
-    test_folder_absolute_path,
-    "-run",
-    "^" .. test_name .. "$",
-  }
-
-  local combined_args =
-    vim.list_extend(vim.deepcopy(M.Adapter._go_test_args), go_test_args)
-  local gotest_command = vim.list_extend(vim.deepcopy(gotest), combined_args)
-
-  ---@type neotest.RunSpec
-  local run_spec = {
-    command = gotest_command,
-    cwd = test_folder_absolute_path,
-    context = {
-      id = pos.id,
-      test_filepath = pos.path,
-    },
-  }
-
-  -- set up for debugging of test
-  if strategy == "dap" then
-    run_spec.strategy = M.get_dap_config(test_name)
-    run_spec.context.skip = true -- do not attempt to parse test output
-
-    -- nvim-dap and nvim-dap-go cwd
-    if M.Adapter._dap_go_enabled then
-      local dap_go_opts = M.Adapter._dap_go_opts or {}
-      local dap_go_opts_original = vim.deepcopy(dap_go_opts)
-      if dap_go_opts.delve == nil then
-        dap_go_opts.delve = {}
-      end
-      dap_go_opts.delve.cwd = test_folder_absolute_path
-      require("dap-go").setup(dap_go_opts)
-
-      -- reset nvim-dap-go (and cwd) after debugging with nvim-dap
-      require("dap").listeners.after.event_terminated["neotest-golang-debug"] = function()
-        require("dap-go").setup(dap_go_opts_original)
-      end
-    end
-  end
-
-  return run_spec
-end
-
----@param test_name string
----@return table | nil
-function M.get_dap_config(test_name)
-  -- :help dap-configuration
-  local dap_config = {
-    type = "go",
-    name = "Neotest-golang",
-    request = "launch",
-    mode = "test",
-    program = "${fileDirname}",
-    args = { "-test.run", "^" .. test_name .. "$" },
-  }
-
-  return dap_config
-end
-
-function M.table_is_empty(t)
-  return next(t) == nil
-end
-
---- Process JSON and return objects of interest
----@param raw_output table
----@return table
-function M.process_json(raw_output)
-  ---@type table
-  local jsonlines = {}
-
-  for _, line in ipairs(raw_output) do
-    if string.match(line, "^%s*{") then
-      local json_data = vim.fn.json_decode(line)
-      table.insert(jsonlines, json_data)
-    else
-      -- TODO: log these to file instead...
-      -- vim.notify("Warning, not a json line: " .. line)
-    end
-  end
-  return jsonlines
-end
-
----@type List
-M.Adapter._go_test_args = {
-  "-v",
-  "-race",
-  "-count=1",
-  "-timeout=60s",
-}
-
--- nvim-dap-go config
-M.Adapter._dap_go_enabled = false
-M.Adapter._dap_go_opts = {}
 
 setmetatable(M.Adapter, {
   __call = function(_, opts)
@@ -434,12 +141,12 @@ M.Adapter.setup = function(opts)
   end
   if opts.go_test_args then
     if opts.go_test_args then
-      M.Adapter._go_test_args = opts.go_test_args
+      options._go_test_args = opts.go_test_args
     end
     if opts.dap_go_enabled then
-      M.Adapter._dap_go_enabled = opts.dap_go_enabled
+      options._dap_go_enabled = opts.dap_go_enabled
       if opts.dap_go_opts then
-        M.Adapter._dap_go_opts = opts.dap_go_opts
+        options._dap_go_opts = opts.dap_go_opts
       end
     end
   end

--- a/lua/neotest-golang/init.lua
+++ b/lua/neotest-golang/init.lua
@@ -1,5 +1,8 @@
+-- This is the main entry point for the neotest-golang adapter. It follows the
+-- Neotest interface: https://github.com/nvim-neotest/neotest/blob/master/lua/neotest/adapters/interface.lua
+
 local options = require("neotest-golang.options")
-local discover_positions = require("neotest-golang.discover_positions")
+local ast = require("neotest-golang.ast")
 local runspec_dir = require("neotest-golang.runspec_dir")
 local runspec_test = require("neotest-golang.runspec_test")
 local results_dir = require("neotest-golang.results_dir")
@@ -54,7 +57,7 @@ end
 ---@param file_path string Absolute file path
 ---@return neotest.Tree | nil
 function M.Adapter.discover_positions(file_path)
-  return discover_positions.discover_positions(file_path)
+  return ast.detect_tests(file_path)
 end
 
 ---Build the runspec, which describes how to execute the test(s).

--- a/lua/neotest-golang/init.lua
+++ b/lua/neotest-golang/init.lua
@@ -8,7 +8,6 @@ local runspec_file = require("neotest-golang.runspec_file")
 local runspec_test = require("neotest-golang.runspec_test")
 local results_dir = require("neotest-golang.results_dir")
 local results_test = require("neotest-golang.results_test")
-local utils = require("neotest-golang.utils")
 
 local M = {}
 

--- a/lua/neotest-golang/init.lua
+++ b/lua/neotest-golang/init.lua
@@ -145,34 +145,11 @@ function M.Adapter.results(spec, result, tree)
   )
 end
 
+--- Adapter options.
 setmetatable(M.Adapter, {
   __call = function(_, opts)
-    return M.Adapter.setup(opts)
+    return options.setup(opts)
   end,
 })
-
-M.Adapter.setup = function(opts)
-  opts = opts or {}
-  if opts.args or opts.dap_go_args then
-    -- temporary warning
-    vim.notify(
-      "Please update your config, the arguments/opts have changed for neotest-golang.",
-      vim.log.levels.WARN
-    )
-  end
-  if opts.go_test_args then
-    if opts.go_test_args then
-      options._go_test_args = opts.go_test_args
-    end
-    if opts.dap_go_enabled then
-      options._dap_go_enabled = opts.dap_go_enabled
-      if opts.dap_go_opts then
-        options._dap_go_opts = opts.dap_go_opts
-      end
-    end
-  end
-
-  return M.Adapter
-end
 
 return M.Adapter

--- a/lua/neotest-golang/init.lua
+++ b/lua/neotest-golang/init.lua
@@ -1,5 +1,3 @@
-local _ = require("neotest")
-
 local options = require("neotest-golang.options")
 local discover_positions = require("neotest-golang.discover_positions")
 local runspec_dir = require("neotest-golang.runspec_dir")

--- a/lua/neotest-golang/init.lua
+++ b/lua/neotest-golang/init.lua
@@ -104,8 +104,6 @@ function M.Adapter.build_spec(args)
       -- to compile. This approach is too brittle, and therefore this mode is not
       -- supported. Instead, the tests of a file are run as if pos.typ == "test".
 
-      vim.notify("Would've executed a file: " .. pos.path)
-
       return -- delegate test execution to per-test execution
     end
   elseif pos.type == "test" then

--- a/lua/neotest-golang/json.lua
+++ b/lua/neotest-golang/json.lua
@@ -11,10 +11,7 @@ function M.process_json(raw_output)
       if status then
         table.insert(jsonlines, json_data)
       else
-        vim.notify(
-          "Warning, failed to decode JSON: " .. line,
-          vim.log.levels.WARN
-        )
+        vim.notify("Failed to decode JSON: " .. line, vim.log.levels.WARN)
       end
     else
       vim.notify("Warning, not a json line: " .. line, vim.log.levels.DEBUG)

--- a/lua/neotest-golang/json.lua
+++ b/lua/neotest-golang/json.lua
@@ -1,8 +1,8 @@
 local M = {}
 
 --- Process JSON and return objects of interest.
----@param raw_output table
----@return table
+--- @param raw_output table
+--- @return table
 function M.process_json(raw_output)
   local jsonlines = {}
   for _, line in ipairs(raw_output) do

--- a/lua/neotest-golang/json.lua
+++ b/lua/neotest-golang/json.lua
@@ -1,0 +1,22 @@
+local M = {}
+
+--- Process JSON and return objects of interest.
+---@param raw_output table
+---@return table
+function M.process_json(raw_output)
+  ---@type table
+  local jsonlines = {}
+
+  for _, line in ipairs(raw_output) do
+    if string.match(line, "^%s*{") then -- must start with the `{` character
+      local json_data = vim.fn.json_decode(line)
+      table.insert(jsonlines, json_data)
+    else
+      -- TODO: log these to file instead...
+      -- vim.notify("Warning, not a json line: " .. line)
+    end
+  end
+  return jsonlines
+end
+
+return M

--- a/lua/neotest-golang/json.lua
+++ b/lua/neotest-golang/json.lua
@@ -11,10 +11,11 @@ function M.process_json(raw_output)
       if status then
         table.insert(jsonlines, json_data)
       else
-        vim.notify("Failed to decode JSON: " .. line, vim.log.levels.WARN)
+        -- NOTE: this is often hit because of "Vim:E474: Unidentified byte: ..."
+        vim.notify("Failed to decode JSON line: " .. line, vim.log.levels.WARN)
       end
     else
-      vim.notify("Warning, not a json line: " .. line, vim.log.levels.DEBUG)
+      -- vim.notify("Not valid JSON: " .. line, vim.log.levels.DEBUG)
     end
   end
   return jsonlines

--- a/lua/neotest-golang/json.lua
+++ b/lua/neotest-golang/json.lua
@@ -4,16 +4,20 @@ local M = {}
 ---@param raw_output table
 ---@return table
 function M.process_json(raw_output)
-  ---@type table
   local jsonlines = {}
-
   for _, line in ipairs(raw_output) do
     if string.match(line, "^%s*{") then -- must start with the `{` character
-      local json_data = vim.fn.json_decode(line)
-      table.insert(jsonlines, json_data)
+      local status, json_data = pcall(vim.fn.json_decode, line)
+      if status then
+        table.insert(jsonlines, json_data)
+      else
+        vim.notify(
+          "Warning, failed to decode JSON: " .. line,
+          vim.log.levels.WARN
+        )
+      end
     else
-      -- TODO: log these to file instead...
-      -- vim.notify("Warning, not a json line: " .. line)
+      vim.notify("Warning, not a json line: " .. line, vim.log.levels.DEBUG)
     end
   end
   return jsonlines

--- a/lua/neotest-golang/options.lua
+++ b/lua/neotest-golang/options.lua
@@ -1,6 +1,6 @@
--- These are the default options for neotest-golang. You can override them by
--- providing them as arguments to the Adapter function. See the README for mode
--- details and examples.
+--- These are the default options for neotest-golang. You can override them by
+--- providing them as arguments to the Adapter function. See the README for mode
+--- details and examples.
 
 local M = {}
 
@@ -21,5 +21,31 @@ M._dap_go_enabled = false
 --- Options to pass into dap-go.setup.
 --- @type table
 M._dap_go_opts = {}
+
+--- Option setup function. This is what you call when setting up the adapter.
+--- @param opts table
+function M.setup(opts)
+  opts = opts or {}
+  if opts.args or opts.dap_go_args then
+    -- temporary warning
+    vim.notify(
+      "Please update your config, the arguments/opts have changed for neotest-golang.",
+      vim.log.levels.WARN
+    )
+  end
+  if opts.go_test_args then
+    if opts.go_test_args then
+      M._go_test_args = opts.go_test_args
+    end
+    if opts.dap_go_enabled then
+      M._dap_go_enabled = opts.dap_go_enabled
+      if opts.dap_go_opts then
+        M._dap_go_opts = opts.dap_go_opts
+      end
+    end
+  end
+
+  return M.Adapter
+end
 
 return M

--- a/lua/neotest-golang/options.lua
+++ b/lua/neotest-golang/options.lua
@@ -1,0 +1,25 @@
+-- These are the default options for neotest-golang. You can override them by
+-- providing them as arguments to the Adapter function. See the README for mode
+-- details and examples.
+
+local M = {}
+
+--- Arguments to pass into `go test`. Will be combined with arguments required
+--- for neotest-golang to work and execute the expected test(s).
+---@type table
+M._go_test_args = {
+  "-v",
+  "-race",
+  "-count=1",
+  "-timeout=60s",
+}
+
+--- Whether to enable nvim-dap-go.
+---@type boolean
+M._dap_go_enabled = false
+
+--- Options to pass into dap-go.setup.
+---@type table
+M._dap_go_opts = {}
+
+return M

--- a/lua/neotest-golang/options.lua
+++ b/lua/neotest-golang/options.lua
@@ -6,7 +6,7 @@ local M = {}
 
 --- Arguments to pass into `go test`. Will be combined with arguments required
 --- for neotest-golang to work and execute the expected test(s).
----@type table
+--- @type table
 M._go_test_args = {
   "-v",
   "-race",
@@ -15,11 +15,11 @@ M._go_test_args = {
 }
 
 --- Whether to enable nvim-dap-go.
----@type boolean
+--- @type boolean
 M._dap_go_enabled = false
 
 --- Options to pass into dap-go.setup.
----@type table
+--- @type table
 M._dap_go_opts = {}
 
 return M

--- a/lua/neotest-golang/results_dir.lua
+++ b/lua/neotest-golang/results_dir.lua
@@ -24,6 +24,7 @@ local M = {}
 --- @param spec neotest.RunSpec
 --- @param result neotest.StrategyResult
 --- @param tree neotest.Tree
+--- @return table<string, neotest.Result>
 function M.results(spec, result, tree)
   --- The raw output from the 'go test -json' command.
   --- @type table
@@ -39,15 +40,18 @@ function M.results(spec, result, tree)
 
   M.show_warnings(res)
 
+  -- DEBUG: enable the following to see the internal test result data.
+  -- vim.notify(vim.inspect(res), vim.log.levels.DEBUG)
+
   local neotest_results = M.to_neotest_results(spec, result, res, gotest_output)
+
+  -- DEBUG: enable the following to see the final Neotest result.
+  -- vim.notify(vim.inspect(neotest_results), vim.log.levels.DEBUG)
 
   -- FIXME: once output is parsed, erase file contents, so to avoid JSON in
   -- output panel. This is a workaround for now, only because of
   -- https://github.com/nvim-neotest/neotest/issues/391
   vim.fn.writefile({ "" }, result.output)
-
-  -- DEBUG: enable the following to see the collected data
-  -- vim.notify(vim.inspect(internal_results), vim.log.levels.DEBUG)
 
   return neotest_results
 end
@@ -63,8 +67,8 @@ function M.aggregate_data(tree, gotest_output)
   return res
 end
 
---- Generate the internal data which will be used by neotest-golang before.
---- handing over the final results onto Neotest.
+--- Generate the internal test result data which will be used by neotest-golang
+--- before handing over the final results onto Neotest.
 --- @param tree neotest.Tree
 --- @return table<string, TestData>
 function M.gather_neotest_data_and_set_defaults(tree)
@@ -106,7 +110,7 @@ function M.gather_neotest_data_and_set_defaults(tree)
   return res
 end
 
---- Decorate the internal results with go package and test name.
+--- Decorate the internal test result data with go package and test name.
 --- This is an important step to associate the test results with the tree nodes
 --- as the 'go test' JSON output contains keys 'Package' and 'Test'.
 --- @param res table<string, TestData>
@@ -145,7 +149,7 @@ function M.decorate_with_go_package_and_test_name(res, gotest_output)
   return res
 end
 
---- Decorate the internal results with data from the 'go test' output.
+--- Decorate the internal test result data with data from the 'go test' output.
 --- @param res table<string, TestData>
 --- @param gotest_output table
 --- @return table<string, TestData>
@@ -225,7 +229,7 @@ function M.show_warnings(d)
   end
 end
 
---- Convert internal results to Neotest results.
+--- Convert internal test result data to final Neotest results.
 --- @param spec neotest.RunSpec
 --- @param result neotest.StrategyResult
 --- @param res table<string, TestData>

--- a/lua/neotest-golang/results_dir.lua
+++ b/lua/neotest-golang/results_dir.lua
@@ -1,0 +1,134 @@
+local async = require("neotest.async")
+
+local convert = require("neotest-golang.convert")
+local json = require("neotest-golang.json")
+
+local M = {}
+
+---@param spec neotest.RunSpec
+---@param result neotest.StrategyResult
+---@param tree neotest.Tree
+function M.results(spec, result, tree)
+  ---@type table
+  local raw_output = async.fn.readfile(result.output)
+
+  ---@type List<table>
+  local jsonlines = json.process_json(raw_output)
+
+  ---@type List
+  local full_test_output = {}
+
+  --- neotest results
+  ---@type table<string, neotest.Result>
+  local neotest_results = {}
+
+  --- internal results struct
+  ---@type table<string, table>
+  local internal_results = {}
+
+  -- record test names
+  for _, line in ipairs(jsonlines) do
+    if line.Action == "run" and line.Test ~= nil then
+      internal_results[line.Test] = {
+        status = "skipped",
+        output = {},
+        errors = {},
+        node_data = nil,
+      }
+    end
+  end
+
+  -- record test status
+  for _, line in ipairs(jsonlines) do
+    if line.Action == "pass" and line.Test ~= nil then
+      internal_results[line.Test].status = "passed"
+    elseif line.Action == "fail" and line.Test ~= nil then
+      internal_results[line.Test].status = "failed"
+    end
+  end
+
+  -- record error output
+  for _, line in ipairs(jsonlines) do
+    if line.Action == "output" and line.Output ~= nil and line.Test ~= nil then
+      -- append line.Output to output field
+      internal_results[line.Test].output =
+        vim.list_extend(internal_results[line.Test].output, { line.Output })
+      -- search for error message and line number
+      local matched_line_number = string.match(line.Output, "_test%.go:(%d+):")
+      if matched_line_number ~= nil then
+        local line_number = tonumber(matched_line_number)
+        local message = string.match(line.Output, "_test%.go:%d+: (.*)")
+        if line_number ~= nil and message ~= nil then
+          table.insert(internal_results[line.Test].errors, {
+            line = line_number - 1, -- neovim lines are 0-indexed
+            message = message,
+          })
+        end
+      end
+    end
+  end
+
+  -- associate internal results with neotest node data
+  for test_name, test_properties in pairs(internal_results) do
+    local test_name_pattern = convert.to_neotest_test_name_pattern(test_name)
+    for _, node in tree:iter_nodes() do
+      local node_data = node:data()
+
+      -- WARNING: workarounds
+      local tweaked_node_data_id = node_data.id:gsub('"', "") -- workaround, since we cannot know where double quotes might appear
+      local tweaked_node_data_id = tweaked_node_data_id:gsub("_", " ") -- NOTE: look into making this more clear...
+
+      if
+        string.find(node_data.path, spec.context.id, 1, true)
+        and string.find(tweaked_node_data_id, test_name_pattern, 1, false)
+      then
+        internal_results[test_name].node_data = node_data
+      end
+    end
+  end
+
+  -- populate neotest results
+  for test_name, test_properties in pairs(internal_results) do
+    if test_properties.node_data ~= nil then
+      local test_output_path = vim.fs.normalize(async.fn.tempname())
+      async.fn.writefile(test_properties.output, test_output_path)
+      neotest_results[test_properties.node_data.id] = {
+        status = test_properties.status,
+        output = test_output_path, -- NOTE: could be slow when running many tests?
+        errors = test_properties.errors,
+      }
+    end
+  end
+
+  ---@type neotest.ResultStatus
+  local test_command_status = "skipped"
+  if result.code == 0 then
+    test_command_status = "passed"
+  else
+    test_command_status = "failed"
+  end
+
+  -- write full test command output
+  local parsed_output_path = vim.fs.normalize(async.fn.tempname())
+  for _, line in ipairs(jsonlines) do
+    if line.Action == "output" then
+      table.insert(full_test_output, line.Output)
+    end
+  end
+  async.fn.writefile(full_test_output, parsed_output_path)
+
+  -- register properties on the directory node that was run
+  neotest_results[spec.context.id] = {
+    status = test_command_status,
+    output = parsed_output_path,
+  }
+
+  -- FIXME: once output is parsed, erase file contents, so to avoid JSON in
+  -- output panel. This is a workaround for now, only because of
+  -- https://github.com/nvim-neotest/neotest/issues/391
+  vim.fn.writefile({ "" }, result.output)
+
+  return neotest_results
+end
+
+return M

--- a/lua/neotest-golang/results_dir.lua
+++ b/lua/neotest-golang/results_dir.lua
@@ -161,7 +161,6 @@ function M.decorate_with_go_test_results(res, gotest_output)
         elseif line.Action == "fail" then
           test_data.status = "failed"
         elseif line.Action == "output" then
-          -- append line.Output to output field
           test_data.gotest_data.output =
             vim.list_extend(test_data.gotest_data.output, { line.Output })
 

--- a/lua/neotest-golang/results_dir.lua
+++ b/lua/neotest-golang/results_dir.lua
@@ -224,7 +224,7 @@ function M.show_warnings(d)
   end
 end
 
---- Convert internal test result data to final Neotest results.
+--- Populate final Neotest results based on internal test result data.
 --- @param spec neotest.RunSpec
 --- @param result neotest.StrategyResult
 --- @param res table<string, TestData>
@@ -246,6 +246,25 @@ function M.to_neotest_results(spec, result, res, gotest_output)
     }
   end
 
+  neotest_results =
+    M.decorate_with_command_data(spec, result, gotest_output, neotest_results)
+
+  return neotest_results
+end
+
+--- Decorate the final Neotest results with the data from the test command that
+--- was executed.
+--- @param spec neotest.RunSpec
+--- @param result neotest.StrategyResult
+--- @param gotest_output table
+--- @param neotest_results table<string, neotest.Result>
+--- @return table<string, neotest.Result>
+function M.decorate_with_command_data(
+  spec,
+  result,
+  gotest_output,
+  neotest_results
+)
   --- Test command (e.g. 'go test') status.
   --- @type neotest.ResultStatus
   local test_command_status = "skipped"

--- a/lua/neotest-golang/results_dir.lua
+++ b/lua/neotest-golang/results_dir.lua
@@ -8,7 +8,7 @@ local utils = require("neotest-golang.utils")
 --- @field status neotest.ResultStatus
 --- @field short? string Shortened output string
 --- @field errors? neotest.Error[]
---- @field neotest_node_data neotest.Position
+--- @field neotest_data neotest.Position
 --- @field gotest_data GoTestData
 --- @field duplicate_test_detected boolean
 
@@ -84,7 +84,7 @@ function M.gather_neotest_data_and_set_defaults(tree)
       res[pos.id] = {
         status = "skipped",
         errors = {},
-        neotest_node_data = pos,
+        neotest_data = pos,
         gotest_data = {
           name = "",
           pkg = "",
@@ -115,8 +115,7 @@ function M.decorate_with_go_package_and_test_name(res, gotest_output)
   for pos_id, test_data in pairs(res) do
     for _, line in ipairs(gotest_output) do
       if line.Action == "run" and line.Test ~= nil then
-        local folderpath =
-          vim.fn.fnamemodify(test_data.neotest_node_data.path, ":h")
+        local folderpath = vim.fn.fnamemodify(test_data.neotest_data.path, ":h")
         local match = nil
         local common_path = utils.find_common_path(line.Package, folderpath)
 
@@ -166,9 +165,9 @@ function M.decorate_with_go_test_results(res, gotest_output)
 
           -- determine test filename
           local test_filename = "_test.go" -- approximate test filename
-          if test_data.neotest_node_data ~= nil then
+          if test_data.neotest_data ~= nil then
             -- node data is available, get the exact test filename
-            local test_filepath = test_data.neotest_node_data.path
+            local test_filepath = test_data.neotest_data.path
             test_filename = vim.fn.fnamemodify(test_filepath, ":t")
           end
 

--- a/lua/neotest-golang/results_dir.lua
+++ b/lua/neotest-golang/results_dir.lua
@@ -5,22 +5,6 @@ local json = require("neotest-golang.json")
 
 local M = {}
 
--- Find the common path of two folderpaths.
-function M.find_common_path(path1, path2)
-  local common = {}
-  local path1_parts = vim.split(path1, "/")
-  local path2_parts = vim.split(path2, "/")
-  for i = #path1_parts, 1, -1 do
-    if path1_parts[i] == path2_parts[#path2_parts] then
-      table.insert(common, 1, path1_parts[i])
-      table.remove(path2_parts)
-    else
-      break
-    end
-  end
-  return table.concat(common, "/")
-end
-
 ---@param spec neotest.RunSpec
 ---@param result neotest.StrategyResult
 ---@param tree neotest.Tree

--- a/lua/neotest-golang/results_dir.lua
+++ b/lua/neotest-golang/results_dir.lua
@@ -72,12 +72,8 @@ function M.results(spec, result, tree)
         status = "skipped",
         output = {},
         errors = {},
-        -- go_test_name = convert.to_gotest_test_name(node_data.id),
         neotest_node_data = node_data,
-        go_package = "",
-        go_test_name = "",
-        -- filename = "",
-        -- pattern = "",
+        go_test_data = {},
       }
     end
   end
@@ -119,8 +115,10 @@ function M.results(spec, result, tree)
           match = tweaked_neotest_node_id:match(combined_pattern)
         end
         if match ~= nil then
-          internal_results[neotest_node_id].go_package = line.Package
-          internal_results[neotest_node_id].go_test_name = line.Test
+          internal_results[neotest_node_id].go_test_data = {
+            package = line.Package,
+            test_name = line.Test,
+          }
 
           break
         end
@@ -131,8 +129,9 @@ function M.results(spec, result, tree)
   for neotest_node_id in pairs(internal_results) do
     for _, line in ipairs(jsonlines) do
       if
-        internal_results[neotest_node_id].go_package == line.Package
-        and internal_results[neotest_node_id].go_test_name == line.Test
+        internal_results[neotest_node_id].go_test_data.package == line.Package
+        and internal_results[neotest_node_id].go_test_data.test_name
+          == line.Test
       then
         -- record test status
         if line.Action == "pass" then
@@ -177,7 +176,7 @@ function M.results(spec, result, tree)
   -- warn if Go package/test is missing from tree node.
   -- TODO: make configurable to skip this or use different log level?
   for neotest_node_id in pairs(internal_results) do
-    if internal_results[neotest_node_id].go_test_name == "" then
+    if internal_results[neotest_node_id].go_test_data.test_name == "" then
       vim.notify(
         "Go package/test not found in tree node: " .. neotest_node_id,
         vim.log.levels.WARN

--- a/lua/neotest-golang/results_dir.lua
+++ b/lua/neotest-golang/results_dir.lua
@@ -48,11 +48,6 @@ function M.results(spec, result, tree)
   -- DEBUG: enable the following to see the final Neotest result.
   -- vim.notify(vim.inspect(neotest_results), vim.log.levels.DEBUG)
 
-  -- FIXME: once output is parsed, erase file contents, so to avoid JSON in
-  -- output panel. This is a workaround for now, only because of
-  -- https://github.com/nvim-neotest/neotest/issues/391
-  vim.fn.writefile({ "" }, result.output)
-
   return neotest_results
 end
 

--- a/lua/neotest-golang/results_test.lua
+++ b/lua/neotest-golang/results_test.lua
@@ -7,7 +7,7 @@ local M = {}
 ---@param result neotest.StrategyResult
 ---@param tree neotest.Tree
 ---@return table<string, neotest.Result>
-function M.results_test(spec, result, tree)
+function M.results(spec, result, tree)
   if spec.context.skip then
     ---@type table<string, neotest.Result>
     local results = {}

--- a/lua/neotest-golang/results_test.lua
+++ b/lua/neotest-golang/results_test.lua
@@ -2,11 +2,11 @@ local async = require("neotest.async")
 
 local M = {}
 
----@async
----@param spec neotest.RunSpec
----@param result neotest.StrategyResult
----@param tree neotest.Tree
----@return table<string, neotest.Result>
+--- @async
+--- @param spec neotest.RunSpec
+--- @param result neotest.StrategyResult
+--- @param tree neotest.Tree
+--- @return table<string, neotest.Result>
 function M.results(spec, result, tree)
   if spec.context.skip then
     ---@type table<string, neotest.Result>
@@ -18,7 +18,7 @@ function M.results(spec, result, tree)
     return results
   end
 
-  ---@type neotest.ResultStatus
+  --- @type neotest.ResultStatus
   local result_status = "skipped"
   if result.code == 0 then
     result_status = "passed"
@@ -26,17 +26,17 @@ function M.results(spec, result, tree)
     result_status = "failed"
   end
 
-  ---@type table
+  --- @type table
   local raw_output = async.fn.readfile(result.output)
 
-  ---@type string
+  --- @type string
   local test_filepath = spec.context.test_filepath
   local test_filename = vim.fn.fnamemodify(test_filepath, ":t")
-  ---@type List
+  --- @type table
   local test_result = {}
-  ---@type neotest.Error[]
+  --- @type neotest.Error[]
   local errors = {}
-  ---@type List<table>
+  --- @type table
   local jsonlines = require("neotest-golang.json").process_json(raw_output)
 
   for _, line in ipairs(jsonlines) do

--- a/lua/neotest-golang/results_test.lua
+++ b/lua/neotest-golang/results_test.lua
@@ -1,5 +1,7 @@
 local async = require("neotest.async")
 
+local json = require("neotest-golang.json")
+
 local M = {}
 
 --- @async
@@ -37,9 +39,9 @@ function M.results(spec, result, tree)
   --- @type neotest.Error[]
   local errors = {}
   --- @type table
-  local jsonlines = require("neotest-golang.json").process_json(raw_output)
+  local gotest_output = json.process_json(raw_output)
 
-  for _, line in ipairs(jsonlines) do
+  for _, line in ipairs(gotest_output) do
     if line.Action == "output" and line.Output ~= nil then
       -- record output, prints to output panel
       table.insert(test_result, line.Output)

--- a/lua/neotest-golang/results_test.lua
+++ b/lua/neotest-golang/results_test.lua
@@ -1,0 +1,96 @@
+local async = require("neotest.async")
+
+local M = {}
+
+---@async
+---@param spec neotest.RunSpec
+---@param result neotest.StrategyResult
+---@param tree neotest.Tree
+---@return table<string, neotest.Result>
+function M.results_test(spec, result, tree)
+  if spec.context.skip then
+    ---@type table<string, neotest.Result>
+    local results = {}
+    results[spec.context.id] = {
+      ---@type neotest.ResultStatus
+      status = "skipped",
+    }
+    return results
+  end
+
+  ---@type neotest.ResultStatus
+  local result_status = "skipped"
+  if result.code == 0 then
+    result_status = "passed"
+  else
+    result_status = "failed"
+  end
+
+  ---@type table
+  local raw_output = async.fn.readfile(result.output)
+
+  ---@type string
+  local test_filepath = spec.context.test_filepath
+  local test_filename = vim.fn.fnamemodify(test_filepath, ":t")
+  ---@type List
+  local test_result = {}
+  ---@type neotest.Error[]
+  local errors = {}
+  ---@type List<table>
+  local jsonlines = require("neotest-golang.json").process_json(raw_output)
+
+  for _, line in ipairs(jsonlines) do
+    if line.Action == "output" and line.Output ~= nil then
+      -- record output, prints to output panel
+      table.insert(test_result, line.Output)
+    end
+
+    if result.code ~= 0 and line.Output ~= nil then
+      -- record an error
+      ---@type string
+      local matched_line_number =
+        string.match(line.Output, test_filename .. ":(%d+):")
+
+      if matched_line_number ~= nil then
+        -- attempt to parse the line number...
+        ---@type number | nil
+        local line_number = tonumber(matched_line_number)
+
+        if line_number ~= nil then
+          -- log the error along with its line number (for diagnostics)
+
+          ---@type string
+          local message = string.match(line.Output, ":%d+: (.*)")
+
+          ---@type neotest.Error
+          local error = {
+            message = message,
+            line = line_number - 1, -- neovim lines are 0-indexed
+          }
+          table.insert(errors, error)
+        end
+      end
+    end
+  end
+
+  -- write json_decoded to file
+  local parsed_output_path = vim.fs.normalize(async.fn.tempname())
+  async.fn.writefile(test_result, parsed_output_path)
+
+  ---@type table<string, neotest.Result>
+  local results = {}
+  results[spec.context.id] = {
+    status = result_status,
+    output = parsed_output_path,
+    errors = errors,
+  }
+
+  -- FIXME: once output is parsed, erase file contents, so to avoid JSON in
+  -- output panel. This is a workaround for now, only because of
+  -- https://github.com/nvim-neotest/neotest/issues/391
+  vim.fn.writefile({ "" }, result.output)
+
+  return results
+end
+
+return M

--- a/lua/neotest-golang/results_test.lua
+++ b/lua/neotest-golang/results_test.lua
@@ -85,11 +85,6 @@ function M.results(spec, result, tree)
     errors = errors,
   }
 
-  -- FIXME: once output is parsed, erase file contents, so to avoid JSON in
-  -- output panel. This is a workaround for now, only because of
-  -- https://github.com/nvim-neotest/neotest/issues/391
-  vim.fn.writefile({ "" }, result.output)
-
   return results
 end
 

--- a/lua/neotest-golang/runspec_dir.lua
+++ b/lua/neotest-golang/runspec_dir.lua
@@ -1,0 +1,88 @@
+local _ = require("neotest") -- fix LSP errors
+
+local options = require("neotest-golang.options")
+
+local M = {}
+
+--- Build runspec for a directory.
+---@param pos neotest.Position
+---@return neotest.RunSpec
+function M.build(pos)
+  -- Strategy:
+  -- 1. Find the go.mod file from pos.path.
+  -- 2. Run `go test` from the directory containing the go.mod file.
+  -- 3. Use the relative path from the go.mod file to pos.path as the test pattern.
+
+  local go_mod_filepath = M.find_file_upwards("go.mod", pos.path)
+  local go_mod_folderpath = vim.fn.fnamemodify(go_mod_filepath, ":h")
+  local cwd = go_mod_folderpath
+
+  -- calculate the relative path to pos.path from cwd
+  local relative_path = M.remove_base_path(cwd, pos.path)
+  local test_pattern = "./" .. relative_path .. "/..."
+
+  return M.build_dir_test_runspec(pos, cwd, test_pattern)
+end
+
+function M.find_file_upwards(filename, start_path)
+  local scan = require("plenary.scandir")
+  local cwd = vim.fn.getcwd() -- get the current working directory
+  local found_filepath = nil
+  while start_path ~= cwd do
+    local files = scan.scan_dir(
+      start_path,
+      { search_pattern = filename, hidden = true, depth = 1 }
+    )
+    if #files > 0 then
+      found_filepath = files[1]
+      break
+    end
+    start_path = vim.fn.fnamemodify(start_path, ":h") -- go up one directory
+  end
+  return found_filepath
+end
+
+function M.remove_base_path(base_path, target_path)
+  if string.find(target_path, base_path, 1, true) == 1 then
+    return string.sub(target_path, string.len(base_path) + 2)
+  end
+
+  return target_path
+end
+
+--- Build runspec for a directory of tests
+---@param pos neotest.Position
+---@param cwd string
+---@param test_pattern string
+---@return neotest.RunSpec
+function M.build_dir_test_runspec(pos, cwd, test_pattern)
+  local gotest = {
+    "go",
+    "test",
+    "-json",
+  }
+
+  ---@type table
+  local go_test_args = {
+    test_pattern,
+  }
+
+  local combined_args =
+    vim.list_extend(vim.deepcopy(options._go_test_args), go_test_args)
+  local gotest_command = vim.list_extend(vim.deepcopy(gotest), combined_args)
+
+  ---@type neotest.RunSpec
+  local run_spec = {
+    command = gotest_command,
+    cwd = cwd,
+    context = {
+      id = pos.id,
+      test_filepath = pos.path,
+      test_type = "dir",
+    },
+  }
+
+  return run_spec
+end
+
+return M

--- a/lua/neotest-golang/runspec_dir.lua
+++ b/lua/neotest-golang/runspec_dir.lua
@@ -3,8 +3,8 @@ local options = require("neotest-golang.options")
 local M = {}
 
 --- Build runspec for a directory.
----@param pos neotest.Position
----@return neotest.RunSpec | nil
+--- @param pos neotest.Position
+--- @return neotest.RunSpec | nil
 function M.build(pos)
   -- Strategy:
   -- 1. Find the go.mod file from pos.path.
@@ -56,10 +56,10 @@ function M.remove_base_path(base_path, target_path)
 end
 
 --- Build runspec for a directory of tests
----@param pos neotest.Position
----@param cwd string
----@param test_pattern string
----@return neotest.RunSpec
+--- @param pos neotest.Position
+--- @param cwd string
+--- @param test_pattern string
+--- @return neotest.RunSpec
 function M.build_dir_test_runspec(pos, cwd, test_pattern)
   local gotest = {
     "go",
@@ -67,7 +67,7 @@ function M.build_dir_test_runspec(pos, cwd, test_pattern)
     "-json",
   }
 
-  ---@type table
+  --- @type table
   local go_test_args = {
     test_pattern,
   }
@@ -76,7 +76,7 @@ function M.build_dir_test_runspec(pos, cwd, test_pattern)
     vim.list_extend(vim.deepcopy(options._go_test_args), go_test_args)
   local gotest_command = vim.list_extend(vim.deepcopy(gotest), combined_args)
 
-  ---@type neotest.RunSpec
+  --- @type neotest.RunSpec
   local run_spec = {
     command = gotest_command,
     cwd = cwd,

--- a/lua/neotest-golang/runspec_dir.lua
+++ b/lua/neotest-golang/runspec_dir.lua
@@ -1,5 +1,3 @@
-local _ = require("neotest") -- fix LSP errors
-
 local options = require("neotest-golang.options")
 
 local M = {}

--- a/lua/neotest-golang/runspec_dir.lua
+++ b/lua/neotest-golang/runspec_dir.lua
@@ -6,14 +6,21 @@ local M = {}
 
 --- Build runspec for a directory.
 ---@param pos neotest.Position
----@return neotest.RunSpec
+---@return neotest.RunSpec | nil
 function M.build(pos)
   -- Strategy:
   -- 1. Find the go.mod file from pos.path.
   -- 2. Run `go test` from the directory containing the go.mod file.
   -- 3. Use the relative path from the go.mod file to pos.path as the test pattern.
-
   local go_mod_filepath = M.find_file_upwards("go.mod", pos.path)
+  if go_mod_filepath == nil then
+    vim.notify(
+      "The selected folder is not a Go project, attempting different strategy.",
+      vim.log.levels.WARN
+    )
+    return nil -- Deletgates away from the dir strategy
+  end
+
   local go_mod_folderpath = vim.fn.fnamemodify(go_mod_filepath, ":h")
   local cwd = go_mod_folderpath
 

--- a/lua/neotest-golang/runspec_file.lua
+++ b/lua/neotest-golang/runspec_file.lua
@@ -1,0 +1,30 @@
+local utils = require("neotest-golang.utils")
+
+local M = {}
+
+--- Build runspec for a directory.
+--- @param pos neotest.Position
+--- @param tree neotest.Tree
+--- @return neotest.RunSpec | nil
+function M.build(pos, tree)
+  if utils.table_is_empty(tree:children()) then
+    --- Runspec designed for files that contain no tests.
+    --- @type neotest.RunSpec
+    local run_spec = {
+      command = { "echo", "No tests found in file" },
+      context = {
+        id = pos.id,
+        skip = true,
+        test_type = "test", -- TODO: to be implemented as "file" later
+      },
+    }
+    return run_spec
+  else
+    -- TODO: Implement a runspec for a file of tests.
+    -- A bare return will delegate test execution to per-test execution, which
+    -- will have to do for now.
+    return
+  end
+end
+
+return M

--- a/lua/neotest-golang/runspec_test.lua
+++ b/lua/neotest-golang/runspec_test.lua
@@ -4,13 +4,13 @@ local options = require("neotest-golang.options")
 local M = {}
 
 --- Build runspec for a single test
----@param pos neotest.Position
----@param strategy string
----@return neotest.RunSpec
+--- @param pos neotest.Position
+--- @param strategy string
+--- @return neotest.RunSpec
 function M.build(pos, strategy)
-  ---@type string
+  --- @type string
   local test_name = convert.to_gotest_test_name(pos.id)
-  ---@type string
+  --- @type string
   local test_folder_absolute_path = string.match(pos.path, "(.+)/")
 
   local gotest = {
@@ -19,7 +19,7 @@ function M.build(pos, strategy)
     "-json",
   }
 
-  ---@type table
+  --- @type table
   local go_test_args = {
     test_folder_absolute_path,
     "-run",
@@ -30,7 +30,7 @@ function M.build(pos, strategy)
     vim.list_extend(vim.deepcopy(options._go_test_args), go_test_args)
   local gotest_command = vim.list_extend(vim.deepcopy(gotest), combined_args)
 
-  ---@type neotest.RunSpec
+  --- @type neotest.RunSpec
   local run_spec = {
     command = gotest_command,
     cwd = test_folder_absolute_path,
@@ -66,8 +66,8 @@ function M.build(pos, strategy)
   return run_spec
 end
 
----@param test_name string
----@return table | nil
+--- @param test_name string
+--- @return table | nil
 function M.get_dap_config(test_name)
   -- :help dap-configuration
   local dap_config = {

--- a/lua/neotest-golang/runspec_test.lua
+++ b/lua/neotest-golang/runspec_test.lua
@@ -1,0 +1,85 @@
+local convert = require("neotest-golang.convert")
+local options = require("neotest-golang.options")
+
+local M = {}
+
+--- Build runspec for a single test
+---@param pos neotest.Position
+---@param strategy string
+---@return neotest.RunSpec
+function M.build(pos, strategy)
+  ---@type string
+  local test_name = convert.to_gotest_test_name(pos.id)
+  ---@type string
+  local test_folder_absolute_path = string.match(pos.path, "(.+)/")
+
+  local gotest = {
+    "go",
+    "test",
+    "-json",
+  }
+
+  ---@type table
+  local go_test_args = {
+    test_folder_absolute_path,
+    "-run",
+    "^" .. test_name .. "$",
+  }
+
+  local combined_args =
+    vim.list_extend(vim.deepcopy(options._go_test_args), go_test_args)
+  local gotest_command = vim.list_extend(vim.deepcopy(gotest), combined_args)
+
+  ---@type neotest.RunSpec
+  local run_spec = {
+    command = gotest_command,
+    cwd = test_folder_absolute_path,
+    context = {
+      id = pos.id,
+      test_filepath = pos.path,
+      test_type = "test",
+    },
+  }
+
+  -- set up for debugging of test
+  if strategy == "dap" then
+    run_spec.strategy = M.get_dap_config(test_name)
+    run_spec.context.skip = true -- do not attempt to parse test output
+
+    -- nvim-dap and nvim-dap-go cwd
+    if options._dap_go_enabled then
+      local dap_go_opts = options._dap_go_opts or {}
+      local dap_go_opts_original = vim.deepcopy(dap_go_opts)
+      if dap_go_opts.delve == nil then
+        dap_go_opts.delve = {}
+      end
+      dap_go_opts.delve.cwd = test_folder_absolute_path
+      require("dap-go").setup(dap_go_opts)
+
+      -- reset nvim-dap-go (and cwd) after debugging with nvim-dap
+      require("dap").listeners.after.event_terminated["neotest-golang-debug"] = function()
+        require("dap-go").setup(dap_go_opts_original)
+      end
+    end
+  end
+
+  return run_spec
+end
+
+---@param test_name string
+---@return table | nil
+function M.get_dap_config(test_name)
+  -- :help dap-configuration
+  local dap_config = {
+    type = "go",
+    name = "Neotest-golang",
+    request = "launch",
+    mode = "test",
+    program = "${fileDirname}",
+    args = { "-test.run", "^" .. test_name .. "$" },
+  }
+
+  return dap_config
+end
+
+return M

--- a/lua/neotest-golang/utils.lua
+++ b/lua/neotest-golang/utils.lua
@@ -7,4 +7,20 @@ function M.table_is_empty(t)
   return next(t) == nil
 end
 
+-- Find the common path of two folderpaths.
+function M.find_common_path(path1, path2)
+  local common = {}
+  local path1_parts = vim.split(path1, "/")
+  local path2_parts = vim.split(path2, "/")
+  for i = #path1_parts, 1, -1 do
+    if path1_parts[i] == path2_parts[#path2_parts] then
+      table.insert(common, 1, path1_parts[i])
+      table.remove(path2_parts)
+    else
+      break
+    end
+  end
+  return table.concat(common, "/")
+end
+
 return M

--- a/lua/neotest-golang/utils.lua
+++ b/lua/neotest-golang/utils.lua
@@ -1,0 +1,10 @@
+local M = {}
+
+---Check if a table is empty.
+---@param t table
+---@return boolean
+function M.table_is_empty(t)
+  return next(t) == nil
+end
+
+return M

--- a/lua/neotest-golang/utils.lua
+++ b/lua/neotest-golang/utils.lua
@@ -1,8 +1,8 @@
 local M = {}
 
----Check if a table is empty.
----@param t table
----@return boolean
+--- Check if a table is empty.
+--- @param t table
+--- @return boolean
 function M.table_is_empty(t)
   return next(t) == nil
 end

--- a/lua/neotest-golang/utils.lua
+++ b/lua/neotest-golang/utils.lua
@@ -7,7 +7,10 @@ function M.table_is_empty(t)
   return next(t) == nil
 end
 
--- Find the common path of two folderpaths.
+--- Find the common path of two folderpaths.
+--- @param path1 string
+--- @param path2 string
+--- @return string
 function M.find_common_path(path1, path2)
   local common = {}
   local path1_parts = vim.split(path1, "/")

--- a/tests/go/testname_spec.lua
+++ b/tests/go/testname_spec.lua
@@ -1,6 +1,7 @@
 local nio = require("nio")
 local adapter = require("neotest-golang")
 local convert = require("neotest-golang.convert")
+local _ = require("plenary") -- for plenary keywords
 
 describe("Subtest name conversion", function()
   -- Arrange
@@ -28,8 +29,9 @@ describe("Subtest name conversion", function()
   end)
 
   it("Special characters", function()
-    local expected_subtest_name = '"Comma , and \' are ok to use"'
-    local expected_gotest_name = "TestNames/Comma_,_and_'_are_ok_to_use"
+    local expected_subtest_name = '"Comma , and apostrophy \' are ok to use"'
+    local expected_gotest_name =
+      "TestNames/Comma_,_and_apostrophy_'_are_ok_to_use"
 
     -- Act
     local pos = tree:node(4):data()

--- a/tests/go/testname_test.go
+++ b/tests/go/testname_test.go
@@ -10,13 +10,19 @@ func TestNames(t *testing.T) {
 		}
 	})
 
-	t.Run("Comma , and ' are ok to use", func(t *testing.T) {
+	t.Run("Comma , and apostrophy ' are ok to use", func(t *testing.T) {
 		if Add(1, 2) != 3 {
 			t.Fail()
 		}
 	})
 
 	t.Run("Brackets [1] (2) {3} are ok", func(t *testing.T) {
+		if Add(1, 2) != 3 {
+			t.Fail()
+		}
+	})
+
+	t.Run("Percentage sign like 50% is ok", func(t *testing.T) {
 		if Add(1, 2) != 3 {
 			t.Fail()
 		}

--- a/tests/unit/results_dir_spec.lua
+++ b/tests/unit/results_dir_spec.lua
@@ -1,13 +1,13 @@
 local _ = require("plenary")
 
-local results_dir = require("neotest-golang.results_dir")
+local results_dir = require("neotest-golang.utils")
 
 describe("Common parts of Go package and folderpath", function()
   it("Root repo - ok", function()
     local line_package = "github.com/fredrikaverpil/my-service"
     local folderpath = "/Users/fredrik/code/work/private/my-service"
 
-    local partial_path = results_dir.common_parts(line_package, folderpath)
+    local partial_path = results_dir.find_common_path(line_package, folderpath)
     assert.are_equal(partial_path, "my-service")
   end)
 
@@ -15,7 +15,7 @@ describe("Common parts of Go package and folderpath", function()
     local line_package = "github.com/fredrikaverpil/my-service/backend"
     local folderpath = "/Users/fredrik/code/work/private/my-service/backend"
 
-    local partial_path = results_dir.common_parts(line_package, folderpath)
+    local partial_path = results_dir.find_common_path(line_package, folderpath)
     assert.are_equal(partial_path, "my-service/backend")
   end)
 
@@ -25,7 +25,7 @@ describe("Common parts of Go package and folderpath", function()
     local folderpath =
       "/Users/fredrik/code/work/private/my-service/backend/internal/outbound/spanner"
 
-    local partial_path = results_dir.common_parts(line_package, folderpath)
+    local partial_path = results_dir.find_common_path(line_package, folderpath)
     assert.are_equal(
       partial_path,
       "my-service/backend/internal/outbound/spanner"

--- a/tests/unit/results_dir_spec.lua
+++ b/tests/unit/results_dir_spec.lua
@@ -1,0 +1,34 @@
+local _ = require("plenary")
+
+local results_dir = require("neotest-golang.results_dir")
+
+describe("Common parts of Go package and folderpath", function()
+  it("Root repo - ok", function()
+    local line_package = "github.com/fredrikaverpil/my-service"
+    local folderpath = "/Users/fredrik/code/work/private/my-service"
+
+    local partial_path = results_dir.common_parts(line_package, folderpath)
+    assert.are_equal(partial_path, "my-service")
+  end)
+
+  it("Repo sub-folder - ok", function()
+    local line_package = "github.com/fredrikaverpil/my-service/backend"
+    local folderpath = "/Users/fredrik/code/work/private/my-service/backend"
+
+    local partial_path = results_dir.common_parts(line_package, folderpath)
+    assert.are_equal(partial_path, "my-service/backend")
+  end)
+
+  it("Deep repo sub folder - ok", function()
+    local line_package =
+      "github.com/fredrikaverpil/my-service/backend/internal/outbound/spanner"
+    local folderpath =
+      "/Users/fredrik/code/work/private/my-service/backend/internal/outbound/spanner"
+
+    local partial_path = results_dir.common_parts(line_package, folderpath)
+    assert.are_equal(
+      partial_path,
+      "my-service/backend/internal/outbound/spanner"
+    )
+  end)
+end)

--- a/tests/unit/results_dir_spec.lua
+++ b/tests/unit/results_dir_spec.lua
@@ -1,13 +1,13 @@
 local _ = require("plenary")
 
-local results_dir = require("neotest-golang.utils")
+local utils = require("neotest-golang.utils")
 
 describe("Common parts of Go package and folderpath", function()
   it("Root repo - ok", function()
     local line_package = "github.com/fredrikaverpil/my-service"
     local folderpath = "/Users/fredrik/code/work/private/my-service"
 
-    local partial_path = results_dir.find_common_path(line_package, folderpath)
+    local partial_path = utils.find_common_path(line_package, folderpath)
     assert.are_equal(partial_path, "my-service")
   end)
 
@@ -15,7 +15,7 @@ describe("Common parts of Go package and folderpath", function()
     local line_package = "github.com/fredrikaverpil/my-service/backend"
     local folderpath = "/Users/fredrik/code/work/private/my-service/backend"
 
-    local partial_path = results_dir.find_common_path(line_package, folderpath)
+    local partial_path = utils.find_common_path(line_package, folderpath)
     assert.are_equal(partial_path, "my-service/backend")
   end)
 
@@ -25,7 +25,7 @@ describe("Common parts of Go package and folderpath", function()
     local folderpath =
       "/Users/fredrik/code/work/private/my-service/backend/internal/outbound/spanner"
 
-    local partial_path = results_dir.find_common_path(line_package, folderpath)
+    local partial_path = utils.find_common_path(line_package, folderpath)
     assert.are_equal(
       partial_path,
       "my-service/backend/internal/outbound/spanner"


### PR DESCRIPTION
## Why this change?

- Makes execution of all tests in a folder (or the entire suite) a lot faster. Only
  runs one `go test` command. Could potentially and hopefully lay the
  foundation for implementing a similar or the same behavior when running
  all tests in a file.
- Aims to help us get there for #23

## What was changed

- When running all tests in a folder (from e.g. the summary window), run just
  one `go test` command.
- Parse `go test` output and map the test name to the Neotest node id, return
  status, output and errors per Neotest node id.

## Notes

- There's a bunch of stuff missing and cleanup needed, but some tests are
  passing on my end now.
- The timeout in the (configurable) arguments might have to be addressed
  somehow, as you could time out more easily now in a large project.
- It so far looks promising; might be able to use the same logic for when
  running all tests in a file.
- There are failing commits in this branch, will clean up later.

## Try it out

Set the branch:

```lua
-- lazy.nvim
return {
  {
    "fredrikaverpil/neotest-golang",
    branch = "rnd-run-testfolder-populate-statuses",
  },
}
```