### PR TITLE
Fix: do not include file/lineno in error

### DIFF
--- a/lua/neotest-golang/init.lua
+++ b/lua/neotest-golang/init.lua
@@ -260,7 +260,7 @@ function M.Adapter.results(spec, result, tree)
       -- record an error
       ---@type string
       local matched_line_number =
-        string.match(line.Output, test_filename .. ":(%d+)")
+        string.match(line.Output, test_filename .. ":(%d+):")
 
       if matched_line_number ~= nil then
         -- attempt to parse the line number...
@@ -269,9 +269,13 @@ function M.Adapter.results(spec, result, tree)
 
         if line_number ~= nil then
           -- log the error along with its line number (for diagnostics)
+
+          ---@type string
+          local message = string.match(line.Output, ":%d+: (.*)")
+
           ---@type neotest.Error
           local error = {
-            message = line.Output,
+            message = message,
             line = line_number - 1, -- neovim lines are 0-indexed
           }
           table.insert(errors, error)


### PR DESCRIPTION
## Before
<img width="1132" alt="image" src="https://github.com/fredrikaverpil/neotest-golang/assets/994357/4fc99fb1-39f3-478d-9b89-b1855509fb69">

## After
<img width="1088" alt="image" src="https://github.com/fredrikaverpil/neotest-golang/assets/994357/a7917fab-cf58-4e41-aa21-df786cab7df8">

