### PR TITLE
Add support for position type 'dir'

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Neotest adapter for running Go tests.
 - Inline diagnostics.
 - Works great with
   [andythigpen/nvim-coverage](https://github.com/andythigpen/nvim-coverage) for
-  displaying coverage in the sign column (per-test basis).
+  displaying coverage in the sign column (per-Go package, or per-test basis).
 - Monorepo support (detect, run and debug tests in sub-projects).
 - Supports table tests (relies on treesitter AST detection).
 - Supports nested test functions.
@@ -30,7 +30,9 @@ My next focus areas:
 - [ ] Documentation around expanding new syntax support for table tests via AST
       parsing.
 - [ ] Add debug logging, set up bug report form.
-- [ ] Investigate ways to speed up test execution when running dir/file.
+- [ ] Investigate ways to speed up test execution when executing tests in...
+  - [x] dir
+  - [ ] file
 
 ## 🏓 Background
 
@@ -93,11 +95,12 @@ return {
 
 ## ⚙️ Configuration
 
-| Argument         | Default value                                   | Description                                                                               |
-| ---------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `go_test_args`   | `{ "-v", "-race", "-count=1", "-timeout=60s" }` | Arguments to pass into `go test`.                                                         |
-| `dap_go_enabled` | `false`                                         | Leverage [leoluz/nvim-dap-go](https://github.com/leoluz/nvim-dap-go) for debugging tests. |
-| `dap_go_opts`    | `{}`                                            | Options to pass into `require("dap-go").setup()`.                                         |
+| Argument               | Default value                                   | Description                                                                               |
+| ---------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `go_test_args`         | `{ "-v", "-race", "-count=1", "-timeout=60s" }` | Arguments to pass into `go test`.                                                         |
+| `dap_go_enabled`       | `false`                                         | Leverage [leoluz/nvim-dap-go](https://github.com/leoluz/nvim-dap-go) for debugging tests. |
+| `dap_go_opts`          | `{}`                                            | Options to pass into `require("dap-go").setup()`.                                         |
+| `warn_test_name_dupes` | `true`                                          | Warn about duplicate test names within the same Go package.                               |
 
 ### Example configuration: custom `go test` arguments
 

--- a/lua/neotest-golang/convert.lua
+++ b/lua/neotest-golang/convert.lua
@@ -19,4 +19,45 @@ function M.to_gotest_test_name(pos_id)
   return test_name
 end
 
+--- Escape characters, for usage of string as pattern in Lua..
+--- - `.` (matches any character)
+--- - `%` (used to escape special characters)
+--- - `+` (matches 1 or more of the previous character or class)
+--- - `*` (matches 0 or more of the previous character or class)
+--- - `-` (matches 0 or more of the previous character or class, in the shortest sequence)
+--- - `?` (makes the previous character or class optional)
+--- - `^` (at the start of a pattern, matches the start of the string; in a character class `[]`, negates the class)
+--- - `$` (matches the end of the string)
+--- - `[]` (defines a character class)
+--- - `()` (defines a capture)
+--- - `:` (used in certain pattern items like `%b()`)
+--- - `=` (used in certain pattern items like `%b()`)
+--- - `<` (used in certain pattern items like `%b<>`)
+--- - `>` (used in certain pattern items like `%b<>`)
+--- @param str string
+function M.to_lua_pattern(str)
+  local special_characters = {
+    "%",
+    ".",
+    "+",
+    "*",
+    "-",
+    "?",
+    "^",
+    "$",
+    "[",
+    "]",
+    "(",
+    ")",
+    ":",
+    "=",
+    "<",
+    ">",
+  }
+  for _, character in ipairs(special_characters) do
+    str = str:gsub("%" .. character, "%%%" .. character)
+  end
+  return str
+end
+
 return M

--- a/lua/neotest-golang/json.lua
+++ b/lua/neotest-golang/json.lua
@@ -1,9 +1,9 @@
 local M = {}
 
---- Process JSON and return objects of interest.
+--- Process output from 'go test -json' and return an iterable table.
 --- @param raw_output table
 --- @return table
-function M.process_json(raw_output)
+function M.process_gotest_output(raw_output)
   local jsonlines = {}
   for _, line in ipairs(raw_output) do
     if string.match(line, "^%s*{") then -- must start with the `{` character
@@ -11,7 +11,7 @@ function M.process_json(raw_output)
       if status then
         table.insert(jsonlines, json_data)
       else
-        -- NOTE: this is often hit because of "Vim:E474: Unidentified byte: ..."
+        -- NOTE: this can be hit because of "Vim:E474: Unidentified byte: ..."
         vim.notify("Failed to decode JSON line: " .. line, vim.log.levels.WARN)
       end
     else
@@ -19,6 +19,33 @@ function M.process_json(raw_output)
     end
   end
   return jsonlines
+end
+
+--- Process output from 'go list -json' an iterable lua table.
+--- @param raw_output string
+--- @return table
+function M.process_golist_output(raw_output)
+  -- Split the input into separate JSON objects
+  local json_objects = {}
+  local current_object = ""
+  for line in raw_output:gmatch("[^\r\n]+") do
+    if line:match("^%s*{") and current_object ~= "" then
+      table.insert(json_objects, current_object)
+      current_object = ""
+    end
+    current_object = current_object .. line
+  end
+  table.insert(json_objects, current_object)
+
+  -- Parse each JSON object
+  local objects = {}
+  for _, json_object in ipairs(json_objects) do
+    local obj = vim.fn.json_decode(json_object)
+    table.insert(objects, obj)
+  end
+
+  -- Return the table of objects
+  return objects
 end
 
 return M

--- a/lua/neotest-golang/options.lua
+++ b/lua/neotest-golang/options.lua
@@ -15,6 +15,7 @@ function Opts:new(opts)
     }
   self.dap_go_enabled = opts.dap_go_enabled or false
   self.dap_go_opts = opts.dap_go_opts or {}
+  self.warn_test_name_dupes = opts.warn_test_name_dupes or true
 end
 
 --- A convenience function to get the current options.
@@ -23,6 +24,7 @@ function Opts:get()
     go_test_args = self.go_test_args,
     dap_go_enabled = self.dap_go_enabled,
     dap_go_opts = self.dap_go_opts,
+    warn_test_name_dupes = self.warn_test_name_dupes,
   }
 end
 

--- a/lua/neotest-golang/results_dir.lua
+++ b/lua/neotest-golang/results_dir.lua
@@ -1,0 +1,320 @@
+local async = require("neotest.async")
+
+local options = require("neotest-golang.options")
+local convert = require("neotest-golang.convert")
+local json = require("neotest-golang.json")
+local utils = require("neotest-golang.utils")
+
+--- @class TestData
+--- @field status neotest.ResultStatus
+--- @field short? string Shortened output string
+--- @field errors? neotest.Error[]
+--- @field neotest_data neotest.Position
+--- @field gotest_data GoTestData
+--- @field duplicate_test_detected boolean
+
+--- @class GoTestData
+--- @field name string Go test name.
+--- @field pkg string Go package.
+--- @field output? string[] Go test output.
+
+local M = {}
+
+--- Process the results from the test command executing all tests in a
+--- directory.
+--- @param spec neotest.RunSpec
+--- @param result neotest.StrategyResult
+--- @param tree neotest.Tree
+--- @return table<string, neotest.Result>
+function M.results(spec, result, tree)
+  --- The Neotest position tree node for this execution.
+  --- @type neotest.Position
+  local pos = tree:data()
+
+  --- The raw output from the 'go test -json' command.
+  --- @type table
+  local raw_output = async.fn.readfile(result.output)
+
+  --- The 'go test' JSON output, converted into a lua table.
+  --- @type table
+  local gotest_output = json.process_gotest_output(raw_output)
+
+  --- The 'go list -json' output, converted into a lua table.
+  local golist_output = spec.context.golist_output
+
+  --- @type table<string, neotest.Result>
+  local neotest_result = {}
+
+  --- Test command (e.g. 'go test') status.
+  --- @type neotest.ResultStatus
+  local test_command_status = "skipped"
+  if spec.context.skip == true then
+    test_command_status = "skipped"
+  elseif result.code == 0 then
+    test_command_status = "passed"
+  else
+    test_command_status = "failed"
+  end
+
+  --- Full 'go test' output (parsed from JSON).
+  --- @type table
+  local o = {}
+  local test_command_output_path = vim.fs.normalize(async.fn.tempname())
+  for _, line in ipairs(gotest_output) do
+    if line.Action == "output" then
+      table.insert(o, line.Output)
+    end
+  end
+  async.fn.writefile(o, test_command_output_path)
+
+  -- register properties on the directory node that was run
+  neotest_result[pos.id] = {
+    status = test_command_status,
+    output = test_command_output_path,
+  }
+
+  -- if the test execution was skipped, return early
+  if spec.context.skip == true then
+    return neotest_result
+  end
+
+  --- Internal data structure to store test result data.
+  --- @type table<string, TestData>
+  local res = M.aggregate_data(tree, gotest_output, golist_output)
+
+  -- DEBUG: enable the following to see the internal test result data.
+  -- vim.notify(vim.inspect(res), vim.log.levels.DEBUG)
+
+  -- show various warnings
+  M.show_warnings(res)
+
+  -- Convert internal test result data into final Neotest result.
+  local test_results = M.to_neotest_result(spec, result, res, gotest_output)
+  for k, v in pairs(test_results) do
+    neotest_result[k] = v
+  end
+
+  -- DEBUG: enable the following to see the final Neotest result.
+  -- vim.notify(vim.inspect(neotest_results), vim.log.levels.DEBUG)
+
+  return neotest_result
+end
+
+--- Aggregate neotest data and 'go test' output data.
+--- @param tree neotest.Tree
+--- @param gotest_output table
+--- @param golist_output table
+--- @return table<string, TestData>
+function M.aggregate_data(tree, gotest_output, golist_output)
+  local res = M.gather_neotest_data_and_set_defaults(tree)
+  res =
+    M.decorate_with_go_package_and_test_name(res, gotest_output, golist_output)
+  res = M.decorate_with_go_test_results(res, gotest_output)
+  return res
+end
+
+--- Generate the internal test result data which will be used by neotest-golang
+--- before handing over the final results onto Neotest.
+--- @param tree neotest.Tree
+--- @return table<string, TestData>
+function M.gather_neotest_data_and_set_defaults(tree)
+  --- Internal data structure to store test result data.
+  --- @type table<string, TestData>
+  local res = {}
+
+  --- Table storing the name of the test (position.id) and the number of times
+  --- it was found in the tree.
+  --- @type table<string, number>
+  local dupes = {}
+
+  for _, node in tree:iter_nodes() do
+    --- @type neotest.Position
+    local pos = node:data()
+
+    if pos.type == "test" then
+      res[pos.id] = {
+        status = "skipped",
+        errors = {},
+        neotest_data = pos,
+        gotest_data = {
+          name = "",
+          pkg = "",
+          output = {},
+        },
+        duplicate_test_detected = false,
+      }
+
+      -- detect duplicate test names
+      if dupes[pos.id] == nil then
+        dupes[pos.id] = 1
+      else
+        dupes[pos.id] = dupes[pos.id] + 1
+        res[pos.id].duplicate_test_detected = true
+      end
+    end
+  end
+  return res
+end
+
+--- Decorate the internal test result data with go package and test name.
+--- This is an important step, in which we figure out exactly which test output
+--- belongs to which test in the Neotest position tree.
+---
+--- The strategy here is to loop over the Neotest position data, and figure out
+--- which position belongs to a specific Go package (using the output from
+--- 'go list -json').
+--- @param res table<string, TestData>
+--- @param gotest_output table
+--- @param golist_output table
+--- @return table<string, TestData>
+function M.decorate_with_go_package_and_test_name(
+  res,
+  gotest_output,
+  golist_output
+)
+  for pos_id, test_data in pairs(res) do
+    local match = nil
+    local folderpath = vim.fn.fnamemodify(test_data.neotest_data.path, ":h")
+    local tweaked_pos_id = pos_id:gsub(" ", "_")
+    tweaked_pos_id = tweaked_pos_id:gsub('"', "")
+    tweaked_pos_id = tweaked_pos_id:gsub("::", "/")
+
+    for _, golistline in ipairs(golist_output) do
+      if folderpath == golistline.Dir then
+        for _, gotestline in ipairs(gotest_output) do
+          if gotestline.Action == "run" and gotestline.Test ~= nil then
+            if gotestline.Package == golistline.ImportPath then
+              local pattern = convert.to_lua_pattern(folderpath)
+                .. "/(.-)/"
+                .. convert.to_lua_pattern(gotestline.Test)
+                .. "$"
+              match = tweaked_pos_id:find(pattern, 1, false)
+              if match ~= nil then
+                test_data.gotest_data.pkg = gotestline.Package
+                test_data.gotest_data.name = gotestline.Test
+                break
+              end
+            end
+            if match ~= nil then
+              break
+            end
+          end
+          if match ~= nil then
+            break
+          end
+        end
+        if match ~= nil then
+          break
+        end
+      end
+    end
+  end
+
+  return res
+end
+
+--- Decorate the internal test result data with data from the 'go test' output.
+--- @param res table<string, TestData>
+--- @param gotest_output table
+--- @return table<string, TestData>
+function M.decorate_with_go_test_results(res, gotest_output)
+  for pos_id, test_data in pairs(res) do
+    for _, line in ipairs(gotest_output) do
+      if
+        test_data.gotest_data.pkg == line.Package
+        and test_data.gotest_data.name == line.Test
+      then
+        -- record test status
+        if line.Action == "pass" then
+          test_data.status = "passed"
+        elseif line.Action == "fail" then
+          test_data.status = "failed"
+        elseif line.Action == "output" then
+          test_data.gotest_data.output =
+            vim.list_extend(test_data.gotest_data.output, { line.Output })
+
+          -- determine test filename
+          local test_filename = "_test.go" -- approximate test filename
+          if test_data.neotest_data ~= nil then
+            -- node data is available, get the exact test filename
+            local test_filepath = test_data.neotest_data.path
+            test_filename = vim.fn.fnamemodify(test_filepath, ":t")
+          end
+
+          -- search for error message and line number
+          local matched_line_number =
+            string.match(line.Output, test_filename .. ":(%d+):")
+          if matched_line_number ~= nil then
+            local line_number = tonumber(matched_line_number)
+            local message =
+              string.match(line.Output, test_filename .. ":%d+: (.*)")
+            if line_number ~= nil and message ~= nil then
+              table.insert(test_data.errors, {
+                line = line_number - 1, -- neovim lines are 0-indexed
+                message = message,
+              })
+            end
+          end
+        end
+      end
+    end
+  end
+  return res
+end
+
+--- Show warnings.
+--- @param d table<string, TestData>
+--- @return nil
+function M.show_warnings(d)
+  -- warn if Go package/test is missing from tree node.
+  for pos_id, test_data in pairs(d) do
+    if test_data.gotest_data.pkg == "" or test_data.gotest_data.name == "" then
+      vim.notify(
+        "Unable to associate go package/test with neotest tree node: " .. pos_id,
+        vim.log.levels.WARN
+      )
+    end
+  end
+
+  -- warn about duplicate tests
+  if options.get().warn_test_name_dupes == true then
+    for pos_id, test_data in pairs(d) do
+      if test_data.duplicate_test_detected == true then
+        vim.notify(
+          "Duplicate test name detected: "
+            .. test_data.gotest_data.pkg
+            .. "/"
+            .. test_data.gotest_data.name,
+          vim.log.levels.WARN
+        )
+      end
+    end
+  end
+end
+
+--- Populate final Neotest results based on internal test result data.
+--- @param spec neotest.RunSpec
+--- @param result neotest.StrategyResult
+--- @param res table<string, TestData>
+--- @param gotest_output table
+--- @return table<string, neotest.Result>
+function M.to_neotest_result(spec, result, res, gotest_output)
+  --- Neotest results.
+  --- @type table<string, neotest.Result>
+  local neotest_result = {}
+
+  -- populate all test results onto the Neotest format.
+  for pos_id, test_data in pairs(res) do
+    local test_output_path = vim.fs.normalize(async.fn.tempname())
+    async.fn.writefile(test_data.gotest_data.output, test_output_path)
+    neotest_result[pos_id] = {
+      status = test_data.status,
+      errors = test_data.errors,
+      output = test_output_path, -- NOTE: could be slow when running many tests?
+    }
+  end
+
+  return neotest_result
+end
+
+return M

--- a/lua/neotest-golang/results_test.lua
+++ b/lua/neotest-golang/results_test.lua
@@ -39,7 +39,7 @@ function M.results(spec, result, tree)
   --- @type neotest.Error[]
   local errors = {}
   --- @type table
-  local gotest_output = json.process_json(raw_output)
+  local gotest_output = json.process_gotest_output(raw_output)
 
   for _, line in ipairs(gotest_output) do
     if line.Action == "output" and line.Output ~= nil then

--- a/lua/neotest-golang/runspec_dir.lua
+++ b/lua/neotest-golang/runspec_dir.lua
@@ -1,0 +1,146 @@
+local options = require("neotest-golang.options")
+local json = require("neotest-golang.json")
+
+local M = {}
+
+--- Build runspec for a directory.
+---
+--- Strategy:
+--- 1. Find the go.mod file from pos.path.
+--- 2. Run `go test` from the directory containing the go.mod file.
+--- 3. Use the relative path from the go.mod file to pos.path as the test pattern.
+--- @param pos neotest.Position
+--- @return neotest.RunSpec | nil
+function M.build(pos)
+  local go_mod_filepath = M.find_file_upwards("go.mod", pos.path)
+
+  -- if go_mod_filepath == nil then
+  --   go_mod_filepath = M.find_file_upwards("go.work", pos.path)
+  -- end
+
+  -- if no go.mod file was found up the directory tree, until reaching $CWD,
+  -- then we cannot determine the Go project root.
+  if go_mod_filepath == nil then
+    local msg = "The selected folder must contain a go.mod file "
+      .. "or be a subdirectory of a Go module."
+    vim.notify(msg, vim.log.levels.ERROR)
+    local run_spec = {
+      command = { "echo", msg },
+      context = {
+        id = pos.id,
+        skip = true,
+        pos_type = "dir",
+      },
+    }
+    return run_spec
+  end
+
+  local go_mod_folderpath = vim.fn.fnamemodify(go_mod_filepath, ":h")
+  local cwd = go_mod_folderpath
+
+  -- call 'go list -json ./...' to get test file data
+  local go_list_command = {
+    "go",
+    "list",
+    "-json",
+    "./...",
+  }
+  local go_list_command_result = vim.fn.system(
+    "cd " .. go_mod_folderpath .. " && " .. table.concat(go_list_command, " ")
+  )
+  local golist_output = json.process_golist_output(go_list_command_result)
+
+  -- find the go module that corresponds to the go_mod_folderpath
+  local module_name = "./..." -- if no go module, run all tests at the $CWD
+  for _, golist_item in ipairs(golist_output) do
+    if pos.path == golist_item.Dir then
+      module_name = golist_item.ImportPath
+      break
+    end
+  end
+
+  return M.build_dir_test_runspec(pos, cwd, golist_output, module_name)
+end
+
+--- Find a file upwards in the directory tree and return its path, if found.
+--- @param filename string
+--- @param start_path string
+--- @return string | nil
+function M.find_file_upwards(filename, start_path)
+  local scan = require("plenary.scandir")
+  local cwd = vim.fn.getcwd()
+  local found_filepath = nil
+  while start_path ~= cwd do
+    local files = scan.scan_dir(
+      start_path,
+      { search_pattern = filename, hidden = true, depth = 1 }
+    )
+    if #files > 0 then
+      found_filepath = files[1]
+      break
+    end
+    start_path = vim.fn.fnamemodify(start_path, ":h") -- go up one directory
+  end
+
+  if found_filepath == nil then
+    -- check if filename exists in the current directory
+    local files = scan.scan_dir(
+      start_path,
+      { search_pattern = filename, hidden = true, depth = 1 }
+    )
+    if #files > 0 then
+      found_filepath = files[1]
+    end
+  end
+
+  return found_filepath
+end
+
+function M.remove_base_path(base_path, target_path)
+  if string.find(target_path, base_path, 1, true) == 1 then
+    return string.sub(target_path, string.len(base_path) + 2)
+  end
+
+  return target_path
+end
+
+--- Build runspec for a directory of tests
+--- @param pos neotest.Position
+--- @param cwd string
+--- @param golist_output table
+--- @param module_name string
+--- @return neotest.RunSpec | neotest.RunSpec[] | nil
+function M.build_dir_test_runspec(pos, cwd, golist_output, module_name)
+  local gotest = {
+    "go",
+    "test",
+    "-json",
+  }
+
+  --- @type table
+  local required_go_test_args = {
+    module_name,
+  }
+
+  local combined_args = vim.list_extend(
+    vim.deepcopy(options.get().go_test_args),
+    required_go_test_args
+  )
+  local gotest_command = vim.list_extend(vim.deepcopy(gotest), combined_args)
+
+  --- @type neotest.RunSpec
+  local run_spec = {
+    command = gotest_command,
+    cwd = cwd,
+    context = {
+      id = pos.id,
+      test_filepath = pos.path,
+      golist_output = golist_output,
+      pos_type = "dir",
+    },
+  }
+
+  return run_spec
+end
+
+return M

--- a/lua/neotest-golang/runspec_file.lua
+++ b/lua/neotest-golang/runspec_file.lua
@@ -5,7 +5,7 @@ local M = {}
 --- Build runspec for a directory.
 --- @param pos neotest.Position
 --- @param tree neotest.Tree
---- @return neotest.RunSpec | nil
+--- @return neotest.RunSpec | neotest.RunSpec[] | nil
 function M.build(pos, tree)
   if utils.table_is_empty(tree:children()) then
     --- Runspec designed for files that contain no tests.
@@ -15,7 +15,7 @@ function M.build(pos, tree)
       context = {
         id = pos.id,
         skip = true,
-        test_type = "test", -- TODO: to be implemented as "file" later
+        pos_type = "test", -- TODO: to be implemented as "file" later
       },
     }
     return run_spec

--- a/lua/neotest-golang/runspec_test.lua
+++ b/lua/neotest-golang/runspec_test.lua
@@ -6,7 +6,7 @@ local M = {}
 --- Build runspec for a single test
 --- @param pos neotest.Position
 --- @param strategy string
---- @return neotest.RunSpec
+--- @return neotest.RunSpec | neotest.RunSpec[] | nil
 function M.build(pos, strategy)
   --- @type string
   local test_name = convert.to_gotest_test_name(pos.id)
@@ -20,14 +20,16 @@ function M.build(pos, strategy)
   }
 
   --- @type table
-  local go_test_args = {
+  local required_go_test_args = {
     test_folder_absolute_path,
     "-run",
     "^" .. test_name .. "$",
   }
 
-  local combined_args =
-    vim.list_extend(vim.deepcopy(options.get().go_test_args), go_test_args)
+  local combined_args = vim.list_extend(
+    vim.deepcopy(options.get().go_test_args),
+    required_go_test_args
+  )
   local gotest_command = vim.list_extend(vim.deepcopy(gotest), combined_args)
 
   --- @type neotest.RunSpec
@@ -37,7 +39,7 @@ function M.build(pos, strategy)
     context = {
       id = pos.id,
       test_filepath = pos.path,
-      test_type = "test",
+      pos_type = "test",
     },
   }
 

--- a/tests/go/testname_spec.lua
+++ b/tests/go/testname_spec.lua
@@ -28,9 +28,10 @@ describe("Subtest name conversion", function()
   end)
 
   it("Special characters", function()
-    local expected_subtest_name = '"Comma , and apostrophy \' are ok to use"'
+    local expected_subtest_name =
+      '"Period . comma , and apostrophy \' are ok to use"'
     local expected_gotest_name =
-      "TestNames/Comma_,_and_apostrophy_'_are_ok_to_use"
+      "TestNames/Period_._comma_,_and_apostrophy_'_are_ok_to_use"
 
     -- Act
     local pos = tree:node(4):data()

--- a/tests/go/testname_test.go
+++ b/tests/go/testname_test.go
@@ -10,7 +10,7 @@ func TestNames(t *testing.T) {
 		}
 	})
 
-	t.Run("Comma , and apostrophy ' are ok to use", func(t *testing.T) {
+	t.Run("Period . comma , and apostrophy ' are ok to use", func(t *testing.T) {
 		if Add(1, 2) != 3 {
 			t.Fail()
 		}

--- a/tests/unit/json_spec.lua
+++ b/tests/unit/json_spec.lua
@@ -1,0 +1,82 @@
+local json = require("neotest-golang.json")
+
+describe("Go list", function()
+  it("Returns one entry", function()
+    local input = [[
+{
+   "Dir": "foo"
+}
+]]
+    local expected = { { Dir = "foo" } }
+    assert.are_same(
+      vim.inspect(expected),
+      vim.inspect(json.process_golist_output(input))
+    )
+  end)
+
+  it("Returns two entries", function()
+    local input = [[{
+   "Dir": "foo"
+}
+{
+   "Dir": "bar"
+}
+]]
+    local expected = { { Dir = "foo" }, { Dir = "bar" } }
+    assert.are_same(
+      vim.inspect(expected),
+      vim.inspect(json.process_golist_output(input))
+    )
+  end)
+
+  it("Returns three entries", function()
+    local input = [[
+{
+   "Dir": "foo"
+}
+{
+   "Dir": "bar"
+}
+{
+   "Dir": "baz"
+}
+]]
+    local expected = { { Dir = "foo" }, { Dir = "bar" }, { Dir = "baz" } }
+    assert.are_same(
+      vim.inspect(expected),
+      vim.inspect(json.process_golist_output(input))
+    )
+  end)
+  it("Returns nested entries", function()
+    local input = [[
+{
+   "Dir": "/Users/fredrik/code/public/neotest-golang/tests/go",
+   "ImportPath": "github.com/fredrikaverpil/neotest-golang",
+   "Module": {
+           "Path": "github.com/fredrikaverpil/neotest-golang",
+           "Main": true,
+           "Dir": "/Users/fredrik/code/public/neotest-golang/tests/go",
+           "GoMod": "/Users/fredrik/code/public/neotest-golang/tests/go/go.mod",
+           "GoVersion": "1.22.2"
+   }
+}
+]]
+    local expected = {
+      {
+        Dir = "/Users/fredrik/code/public/neotest-golang/tests/go",
+        ImportPath = "github.com/fredrikaverpil/neotest-golang",
+        Module = {
+          Path = "github.com/fredrikaverpil/neotest-golang",
+          Main = true,
+          Dir = "/Users/fredrik/code/public/neotest-golang/tests/go",
+          GoMod = "/Users/fredrik/code/public/neotest-golang/tests/go/go.mod",
+          GoVersion = "1.22.2",
+        },
+      },
+    }
+    assert.are_same(
+      vim.inspect(expected),
+      vim.inspect(json.process_golist_output(input))
+    )
+  end)
+end)

--- a/tests/unit/options_spec.lua
+++ b/tests/unit/options_spec.lua
@@ -11,6 +11,7 @@ describe("Options are set up", function()
         "-count=1",
         "-timeout=60s",
       },
+      warn_test_name_dupes = true,
     }
     options.setup()
     assert.are_same(expected_options, options.get())
@@ -27,6 +28,7 @@ describe("Options are set up", function()
         "-parallel=1",
         "-timeout=60s",
       },
+      warn_test_name_dupes = true,
     }
     options.setup(expected_options)
     assert.are_same(expected_options, options.get())


### PR DESCRIPTION
This adds substantial performance improvements on being able to run all tests in
a Go project using one 'go test' command, instead of executing on a per-test
basis.

Either run all tests in the entire test suite (given that you have a `go.mod` in your $cwd):

```lua
require("neotest").run.run({ suite = true })
```

Or select a directory in the Neotest summary window, and hit `r` to execute the tests
in that Go package.
