### PR TITLE
Go test regexp pattern does not escape parenthesis

### DIFF
--- a/lua/neotest-golang/convert.lua
+++ b/lua/neotest-golang/convert.lua
@@ -1,5 +1,20 @@
 local M = {}
 
+-- Converts the test name into a regexp-friendly pattern, for usage in
+-- 'go test'.
+---@param test_name string
+---@return string
+function M.to_gotest_regex_pattern(test_name)
+  local special_characters = {
+    "(",
+    ")",
+  }
+  for _, character in ipairs(special_characters) do
+    test_name = test_name:gsub("%" .. character, "\\" .. character)
+  end
+  return "^" .. test_name .. "$"
+end
+
 -- Converts the AST-detected Neotest node test name into the 'go test' command
 -- test name format.
 ---@param pos_id string

--- a/lua/neotest-golang/runspec_test.lua
+++ b/lua/neotest-golang/runspec_test.lua
@@ -10,6 +10,8 @@ local M = {}
 function M.build(pos, strategy)
   --- @type string
   local test_name = convert.to_gotest_test_name(pos.id)
+  test_name = convert.to_gotest_regex_pattern(test_name)
+
   --- @type string
   local test_folder_absolute_path = string.match(pos.path, "(.+)/")
 
@@ -20,11 +22,7 @@ function M.build(pos, strategy)
   }
 
   --- @type table
-  local required_go_test_args = {
-    test_folder_absolute_path,
-    "-run",
-    "^" .. test_name .. "$",
-  }
+  local required_go_test_args = { test_folder_absolute_path, "-run", test_name }
 
   local combined_args = vim.list_extend(
     vim.deepcopy(options.get().go_test_args),

--- a/tests/go/testname_test.go
+++ b/tests/go/testname_test.go
@@ -27,4 +27,10 @@ func TestNames(t *testing.T) {
 			t.Fail()
 		}
 	})
+
+	t.Run("Test(success)", func(t *testing.T) {
+		if Add(1, 2) != 3 {
+			t.Fail()
+		}
+	})
 }


### PR DESCRIPTION
This has led to false positives when running a single test (or a file of tests).