### PR TITLE
Add debug-level notification when package/test cannot be identified from test output

### DIFF
--- a/lua/neotest-golang/options.lua
+++ b/lua/neotest-golang/options.lua
@@ -17,6 +17,7 @@ function Opts:new(opts)
   self.dap_go_opts = opts.dap_go_opts or {}
   self.warn_test_name_dupes = opts.warn_test_name_dupes or true
   self.warn_test_not_executed = opts.warn_test_not_executed or true
+  self.dev_notifications = opts.dev_notifications or false
 end
 
 --- A convenience function to get the current options.
@@ -27,6 +28,7 @@ function Opts:get()
     dap_go_opts = self.dap_go_opts,
     warn_test_name_dupes = self.warn_test_name_dupes,
     warn_test_not_executed = self.warn_test_not_executed,
+    dev_notifications = self.dev_notifications,
   }
 end
 

--- a/tests/unit/options_spec.lua
+++ b/tests/unit/options_spec.lua
@@ -13,6 +13,7 @@ describe("Options are set up", function()
       },
       warn_test_name_dupes = true,
       warn_test_not_executed = true,
+      dev_notifications = false,
     }
     options.setup()
     assert.are_same(expected_options, options.get())
@@ -31,6 +32,7 @@ describe("Options are set up", function()
       },
       warn_test_name_dupes = true,
       warn_test_not_executed = true,
+      dev_notifications = false,
     }
     options.setup(expected_options)
     assert.are_same(expected_options, options.get())


### PR DESCRIPTION
This notification can be rather chatty in certain projects, so let's add a new dev-type option which can be used to enable it. The default is to have this disabled, as it will show in the test summary window that the test(s) were skipped.

The purpose of this notification is to try and catch bugs for when comparing a package/test from the `go test` test output with Neotest's position id.