### PR TITLE
fix: escaping of []{} brackets were missing

### DIFF
--- a/lua/neotest-golang/convert.lua
+++ b/lua/neotest-golang/convert.lua
@@ -8,6 +8,10 @@ function M.to_gotest_regex_pattern(test_name)
   local special_characters = {
     "(",
     ")",
+    "[",
+    "]",
+    "{",
+    "}",
   }
   for _, character in ipairs(special_characters) do
     test_name = test_name:gsub("%" .. character, "\\" .. character)


### PR DESCRIPTION
### Why?

Having a test like this would result it not being run, and skipped by neotest-golang as the output would include "no tests to run":

```go
package main

import "testing"

// A dummy test, just to assert that Go tests can run.
func TestNames(t *testing.T) {
	t.Run("Brackets [1] (2) {3} are ok", func(t *testing.T) {
		if Add(1, 2) != 3 {
			t.Fail()
		}
	})
}
```

```
=== RUN   TestNames
--- PASS: TestNames (0.00s)
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok      github.com/fredrikaverpil/neotest-golang        1.425s  coverage: 0.0% of statements [no tests to run]

```

### What?

Escape the brackets. Now the test runs fine.