### PR TITLE
feat: initial gotestsum support and larger refactoring

### DIFF
--- a/lua/neotest-golang/cmd.lua
+++ b/lua/neotest-golang/cmd.lua
@@ -3,10 +3,11 @@
 local async = require("neotest.async")
 
 local options = require("neotest-golang.options")
+local json = require("neotest-golang.json")
 
 local M = {}
 
-function M.golist_cmd(cwd)
+function M.golist_output(cwd)
   -- call 'go list -json ./...' to get test file data
   local go_list_command = {
     "go",
@@ -14,9 +15,9 @@ function M.golist_cmd(cwd)
     "-json",
     "./...",
   }
-  local go_list_command_result =
+  local output =
     vim.fn.system("cd " .. cwd .. " && " .. table.concat(go_list_command, " "))
-  return go_list_command_result
+  return json.process_golist_output(output)
 end
 
 function M.fallback_to_go_test(executable)

--- a/lua/neotest-golang/cmd.lua
+++ b/lua/neotest-golang/cmd.lua
@@ -20,6 +20,60 @@ function M.golist_output(cwd)
   return json.process_golist_output(output)
 end
 
+function M.test_command_for_individual_test(
+  test_folder_absolute_path,
+  test_name
+)
+  local go_test_required_args = { test_folder_absolute_path, "-run", test_name }
+  local cmd, json_filepath = M.test_command(go_test_required_args)
+  return cmd, json_filepath
+end
+
+function M.test_command_for_dir(module_name)
+  local go_test_required_args = { module_name }
+  local cmd, json_filepath = M.test_command(go_test_required_args)
+  return cmd, json_filepath
+end
+
+function M.test_command(go_test_required_args)
+  --- The runner to use for running tests.
+  --- @type string
+  local runner = M.fallback_to_go_test(options.get().runner)
+
+  --- The filepath to write test output JSON to, if using `gotestsum`.
+  --- @type string | nil
+  local json_filepath = nil
+
+  --- The final test command to execute.
+  --- @type table<string>
+  local cmd = {}
+
+  if runner == "go" then
+    cmd = M.go_test(go_test_required_args)
+  elseif runner == "gotestsum" then
+    json_filepath = vim.fs.normalize(async.fn.tempname())
+    cmd = M.gotestsum(go_test_required_args, json_filepath)
+  end
+
+  return cmd, json_filepath
+end
+
+function M.go_test(go_test_required_args)
+  local cmd = { "go", "test", "-json" }
+  cmd = vim.list_extend(vim.deepcopy(cmd), options.get().go_test_args)
+  cmd = vim.list_extend(vim.deepcopy(cmd), go_test_required_args)
+  return cmd
+end
+
+function M.gotestsum(go_test_required_args, json_filepath)
+  local cmd = { "gotestsum", "--jsonfile=" .. json_filepath }
+  cmd = vim.list_extend(vim.deepcopy(cmd), options.get().gotestsum_args)
+  cmd = vim.list_extend(vim.deepcopy(cmd), { "--" })
+  cmd = vim.list_extend(vim.deepcopy(cmd), options.get().go_test_args)
+  cmd = vim.list_extend(vim.deepcopy(cmd), go_test_required_args)
+  return cmd
+end
+
 function M.fallback_to_go_test(executable)
   if vim.fn.executable(executable) == 0 then
     vim.notify(
@@ -30,145 +84,6 @@ function M.fallback_to_go_test(executable)
     return options.get().runner
   end
   return options.get().runner
-end
-
-function M.test_command_for_individual_test(cwd, test_name)
-  --- The runner to use for running tests.
-  --- @type string
-  local runner = M.fallback_to_go_test(options.get().runner)
-
-  --- The filepath to write test output JSON to, if using `gotestsum`.
-  --- @type string | nil
-  local json_filepath = nil
-
-  --- The final test command to execute.
-  --- @type table<string>
-  local test_cmd = {}
-
-  if runner == "go" then
-    test_cmd = M.gotest_with_args_for_individual_test(cwd, test_name)
-  elseif runner == "gotestsum" then
-    json_filepath = vim.fs.normalize(async.fn.tempname())
-    test_cmd =
-      M.gotestsum_with_args_for_individual_test(cwd, test_name, json_filepath)
-  end
-
-  return test_cmd, json_filepath
-end
-
-function M.test_command_for_dir(module_name)
-  --- The runner to use for running tests.
-  --- @type string
-  local runner = M.fallback_to_go_test(options.get().runner)
-
-  --- The filepath to write test output JSON to, if using `gotestsum`.
-  --- @type string | nil
-  local json_filepath = nil
-
-  --- The final test command to execute.
-  --- @type table<string>
-  local test_cmd = {}
-
-  if runner == "go" then
-    test_cmd = M.gotest_with_args_for_dir(module_name)
-  elseif runner == "gotestsum" then
-    json_filepath = vim.fs.normalize(async.fn.tempname())
-    test_cmd = M.gotestsum_with_args_cmd_for_dir(module_name, json_filepath)
-  end
-
-  return test_cmd, json_filepath
-end
-
-function M.gotest_with_args_for_dir(module_name)
-  local gotest = {
-    "go",
-    "test",
-    "-json",
-  }
-
-  local required_go_test_args = {
-    module_name,
-  }
-
-  local combined_args = vim.list_extend(
-    vim.deepcopy(options.get().go_test_args),
-    required_go_test_args
-  )
-  local cmd = vim.list_extend(vim.deepcopy(gotest), combined_args)
-
-  return cmd
-end
-
-function M.gotestsum_with_args_cmd_for_dir(module_name, json_filepath)
-  local gotest = { "gotestsum" }
-  local gotestsum_json = {
-    "--jsonfile=" .. json_filepath,
-    "--",
-  }
-
-  local required_go_test_args = {
-    module_name,
-  }
-
-  local gotest_args = vim.list_extend(
-    vim.deepcopy(options.get().go_test_args),
-    required_go_test_args
-  )
-
-  local cmd =
-    vim.list_extend(vim.deepcopy(gotest), options.get().gotestsum_args)
-  cmd = vim.list_extend(vim.deepcopy(cmd), gotestsum_json)
-  cmd = vim.list_extend(vim.deepcopy(cmd), gotest_args)
-
-  return cmd
-end
-
-function M.gotest_with_args_for_individual_test(
-  test_folder_absolute_path,
-  test_name
-)
-  --- @type table
-  local required_go_test_args = { test_folder_absolute_path, "-run", test_name }
-
-  local gotest = {
-    "go",
-    "test",
-    "-json",
-  }
-
-  local combined_args = vim.list_extend(
-    vim.deepcopy(options.get().go_test_args),
-    required_go_test_args
-  )
-  local cmd = vim.list_extend(vim.deepcopy(gotest), combined_args)
-  return cmd
-end
-
-function M.gotestsum_with_args_for_individual_test(
-  test_folder_absolute_path,
-  test_name,
-  json_filepath
-)
-  --- @type table
-  local required_go_test_args = { test_folder_absolute_path, "-run", test_name }
-
-  local gotest = { "gotestsum" }
-  local gotestsum_json = {
-    "--jsonfile=" .. json_filepath,
-    "--",
-  }
-
-  local gotest_args = vim.list_extend(
-    vim.deepcopy(options.get().go_test_args),
-    required_go_test_args
-  )
-
-  local cmd =
-    vim.list_extend(vim.deepcopy(gotest), options.get().gotestsum_args)
-  cmd = vim.list_extend(vim.deepcopy(cmd), gotestsum_json)
-  cmd = vim.list_extend(vim.deepcopy(cmd), gotest_args)
-
-  return cmd
 end
 
 return M

--- a/lua/neotest-golang/cmd.lua
+++ b/lua/neotest-golang/cmd.lua
@@ -1,0 +1,109 @@
+--- Helper functions building the command to execute.
+
+local options = require("neotest-golang.options")
+
+local M = {}
+
+function M.build_golist_cmd(cwd)
+  -- call 'go list -json ./...' to get test file data
+  local go_list_command = {
+    "go",
+    "list",
+    "-json",
+    "./...",
+  }
+  local go_list_command_result =
+    vim.fn.system("cd " .. cwd .. " && " .. table.concat(go_list_command, " "))
+  return go_list_command_result
+end
+
+function M.build_gotest_cmd_for_dir(module_name)
+  local gotest = {
+    "go",
+    "test",
+    "-json",
+  }
+
+  local required_go_test_args = {
+    module_name,
+  }
+
+  local combined_args = vim.list_extend(
+    vim.deepcopy(options.get().go_test_args),
+    required_go_test_args
+  )
+  local cmd = vim.list_extend(vim.deepcopy(gotest), combined_args)
+
+  return cmd
+end
+
+function M.build_gotestsum_cmd_for_dir(module_name, json_filepath)
+  local gotest = { "gotestsum" }
+  local gotestsum_json = {
+    "--jsonfile=" .. json_filepath,
+    "--",
+  }
+
+  local required_go_test_args = {
+    module_name,
+  }
+
+  local gotest_args = vim.list_extend(
+    vim.deepcopy(options.get().go_test_args),
+    required_go_test_args
+  )
+
+  local cmd =
+    vim.list_extend(vim.deepcopy(gotest), options.get().gotestsum_args)
+  cmd = vim.list_extend(vim.deepcopy(cmd), gotestsum_json)
+  cmd = vim.list_extend(vim.deepcopy(cmd), gotest_args)
+
+  return cmd
+end
+
+function M.build_gotest_cmd_for_test(test_folder_absolute_path, test_name)
+  --- @type table
+  local required_go_test_args = { test_folder_absolute_path, "-run", test_name }
+
+  local gotest = {
+    "go",
+    "test",
+    "-json",
+  }
+
+  local combined_args = vim.list_extend(
+    vim.deepcopy(options.get().go_test_args),
+    required_go_test_args
+  )
+  local cmd = vim.list_extend(vim.deepcopy(gotest), combined_args)
+  return cmd
+end
+
+function M.build_gotestsum_cmd_for_test(
+  test_folder_absolute_path,
+  test_name,
+  json_filepath
+)
+  --- @type table
+  local required_go_test_args = { test_folder_absolute_path, "-run", test_name }
+
+  local gotest = { "gotestsum" }
+  local gotestsum_json = {
+    "--jsonfile=" .. json_filepath,
+    "--",
+  }
+
+  local gotest_args = vim.list_extend(
+    vim.deepcopy(options.get().go_test_args),
+    required_go_test_args
+  )
+
+  local cmd =
+    vim.list_extend(vim.deepcopy(gotest), options.get().gotestsum_args)
+  cmd = vim.list_extend(vim.deepcopy(cmd), gotestsum_json)
+  cmd = vim.list_extend(vim.deepcopy(cmd), gotest_args)
+
+  return cmd
+end
+
+return M

--- a/lua/neotest-golang/dap.lua
+++ b/lua/neotest-golang/dap.lua
@@ -1,0 +1,38 @@
+--- DAP setup related functions.
+
+local options = require("neotest-golang.options")
+
+local M = {}
+
+function M.setup_debugging(cwd)
+  local dap_go_opts = options.get().dap_go_opts or {}
+  local dap_go_opts_original = vim.deepcopy(dap_go_opts)
+  if dap_go_opts.delve == nil then
+    dap_go_opts.delve = {}
+  end
+  dap_go_opts.delve.cwd = cwd
+  require("dap-go").setup(dap_go_opts)
+
+  -- reset nvim-dap-go (and cwd) after debugging with nvim-dap
+  require("dap").listeners.after.event_terminated["neotest-golang-debug"] = function()
+    require("dap-go").setup(dap_go_opts_original)
+  end
+end
+
+--- @param test_name string
+--- @return table | nil
+function M.get_dap_config(test_name)
+  -- :help dap-configuration
+  local dap_config = {
+    type = "go",
+    name = "Neotest-golang",
+    request = "launch",
+    mode = "test",
+    program = "${fileDirname}",
+    args = { "-test.run", "^" .. test_name .. "$" },
+  }
+
+  return dap_config
+end
+
+return M

--- a/lua/neotest-golang/init.lua
+++ b/lua/neotest-golang/init.lua
@@ -147,13 +147,13 @@ function M.Adapter.results(spec, result, tree)
   if spec.context.pos_type == "dir" then
     -- A test command executed a directory of tests and the output/status must
     -- now be processed.
-    local results = parse.results(spec, result, tree)
+    local results = parse.test_results(spec, result, tree)
     M.workaround_neotest_issue_391(result)
     return results
   elseif spec.context.pos_type == "test" then
     -- A test command executed a single test and the output/status must now be
     -- processed.
-    local results = parse.results(spec, result, tree)
+    local results = parse.test_results(spec, result, tree)
     M.workaround_neotest_issue_391(result)
     return results
   end

--- a/lua/neotest-golang/init.lua
+++ b/lua/neotest-golang/init.lua
@@ -171,7 +171,9 @@ function M.workaround_neotest_issue_391(result)
   -- FIXME: once output is parsed, erase file contents, so to avoid JSON in
   -- output panel. This is a workaround for now, only because of
   -- https://github.com/nvim-neotest/neotest/issues/391
-  vim.fn.writefile({ "" }, result.output)
+  if result.output ~= nil then
+    vim.fn.writefile({ "" }, result.output)
+  end
 end
 
 --- Adapter options.

--- a/lua/neotest-golang/options.lua
+++ b/lua/neotest-golang/options.lua
@@ -5,11 +5,9 @@
 local M = {}
 
 local opts = {
-  go_test_args = {
-    "-v",
-    "-race",
-    "-count=1",
-  },
+  runner = "go", -- or "gotestsum"
+  go_test_args = { "-v", "-race", "-count=1" },
+  gotestsum_args = { "--format=standard-verbose" },
   dap_go_enabled = false,
   dap_go_opts = {},
   warn_test_name_dupes = true,

--- a/lua/neotest-golang/options.lua
+++ b/lua/neotest-golang/options.lua
@@ -28,4 +28,11 @@ function M.get()
   return opts
 end
 
+function M.set(updated_opts)
+  for k, v in pairs(updated_opts) do
+    opts[k] = v
+  end
+  return opts
+end
+
 return M

--- a/lua/neotest-golang/parse.lua
+++ b/lua/neotest-golang/parse.lua
@@ -43,12 +43,16 @@ function M.results(spec, result, tree)
   --- @type neotest.Position
   local pos = tree:data()
 
+  --- The runner to use for running tests.
+  --- @type string
+  local runner = options.get().runner
+
   --- The raw output from the test command.
   --- @type table
   local raw_output = {}
-  if options.get().runner == "go" then
+  if runner == "go" then
     raw_output = async.fn.readfile(result.output)
-  elseif options.get().runner == "gotestsum" then
+  elseif runner == "gotestsum" then
     raw_output = async.fn.readfile(spec.context.jsonfile)
   end
 

--- a/lua/neotest-golang/parse.lua
+++ b/lua/neotest-golang/parse.lua
@@ -27,7 +27,7 @@ local M = {}
 --- @param result neotest.StrategyResult
 --- @param tree neotest.Tree
 --- @return table<string, neotest.Result>
-function M.results(spec, result, tree)
+function M.test_results(spec, result, tree)
   if spec.context.debug_and_skip == true then
     ---@type table<string, neotest.Result>
     local results = {}

--- a/lua/neotest-golang/parse.lua
+++ b/lua/neotest-golang/parse.lua
@@ -43,9 +43,14 @@ function M.results(spec, result, tree)
   --- @type neotest.Position
   local pos = tree:data()
 
-  --- The raw output from the 'go test -json' command.
+  --- The raw output from the test command.
   --- @type table
-  local raw_output = async.fn.readfile(result.output)
+  local raw_output = {}
+  if options.get().runner == "go" then
+    raw_output = async.fn.readfile(result.output)
+  elseif options.get().runner == "gotestsum" then
+    raw_output = async.fn.readfile(spec.context.jsonfile)
+  end
 
   --- The 'go test' JSON output, converted into a lua table.
   --- @type table

--- a/lua/neotest-golang/parse.lua
+++ b/lua/neotest-golang/parse.lua
@@ -53,7 +53,7 @@ function M.results(spec, result, tree)
   if runner == "go" then
     raw_output = async.fn.readfile(result.output)
   elseif runner == "gotestsum" then
-    raw_output = async.fn.readfile(spec.context.jsonfile)
+    raw_output = async.fn.readfile(spec.context.json_filepath)
   end
 
   --- The 'go test' JSON output, converted into a lua table.

--- a/lua/neotest-golang/parse.lua
+++ b/lua/neotest-golang/parse.lua
@@ -28,7 +28,7 @@ local M = {}
 --- @param tree neotest.Tree
 --- @return table<string, neotest.Result>
 function M.results(spec, result, tree)
-  if spec.context.skip == true then
+  if spec.context.debug_and_skip == true then
     ---@type table<string, neotest.Result>
     local results = {}
     results[spec.context.id] = {
@@ -95,7 +95,7 @@ function M.results(spec, result, tree)
   }
 
   -- if the test execution was skipped, return early
-  if spec.context.skip == true then
+  if spec.context.test_execution_skipped == true then
     return neotest_result
   end
 

--- a/lua/neotest-golang/parse.lua
+++ b/lua/neotest-golang/parse.lua
@@ -35,7 +35,6 @@ function M.test_results(spec, result, tree)
       ---@type neotest.ResultStatus
       status = "skipped", -- default value
     }
-
     return results
   end
 
@@ -56,8 +55,6 @@ function M.test_results(spec, result, tree)
     raw_output = async.fn.readfile(spec.context.json_filepath)
   end
 
-  --- The 'go test' JSON output, converted into a lua table.
-  --- @type table
   local gotest_output = json.process_gotest_output(raw_output)
 
   --- The 'go list -json' output, converted into a lua table.

--- a/lua/neotest-golang/runspec_dir.lua
+++ b/lua/neotest-golang/runspec_dir.lua
@@ -50,26 +50,7 @@ function M.build(pos)
     end
   end
 
-  --- The runner to use for running tests.
-  --- @type string
-  local runner = options.get().runner
-
-  -- TODO: if gotestsum, check if it is on $PATH, or fall back onto `go test`
-
-  --- The filepath to write test output JSON to, if using `gotestsum`.
-  --- @type string | nil
-  local json_filepath = nil
-
-  --- The final test command to execute.
-  --- @type table<string>
-  local test_cmd = {}
-
-  if runner == "go" then
-    test_cmd = cmd.build_gotest_cmd_for_dir(module_name)
-  elseif runner == "gotestsum" then
-    json_filepath = vim.fs.normalize(async.fn.tempname())
-    test_cmd = cmd.build_gotestsum_cmd_for_dir(module_name, json_filepath)
-  end
+  local test_cmd, json_filepath = cmd.build_test_command_for_dir(module_name)
 
   return M.build_runspec(
     pos,
@@ -127,6 +108,7 @@ end
 --- @param cwd string
 --- @param test_cmd table<string>
 --- @param golist_output table
+--- @param json_filepath string | nil
 --- @return neotest.RunSpec | neotest.RunSpec[] | nil
 function M.build_runspec(pos, cwd, test_cmd, golist_output, json_filepath)
   --- @type neotest.RunSpec

--- a/lua/neotest-golang/runspec_dir.lua
+++ b/lua/neotest-golang/runspec_dir.lua
@@ -62,7 +62,7 @@ function M.build(pos)
   }
 
   if json_filepath ~= nil then
-    run_spec.context.jsonfile = json_filepath
+    run_spec.context.json_filepath = json_filepath
   end
 
   return run_spec

--- a/lua/neotest-golang/runspec_dir.lua
+++ b/lua/neotest-golang/runspec_dir.lua
@@ -35,7 +35,7 @@ function M.build(pos)
   end
 
   local go_mod_folderpath = vim.fn.fnamemodify(go_mod_filepath, ":h")
-  local go_list_command = cmd.build_golist_cmd(go_mod_folderpath)
+  local go_list_command = cmd.golist_cmd(go_mod_folderpath)
   local golist_output = json.process_golist_output(go_list_command)
 
   -- find the go module that corresponds to the go_mod_folderpath
@@ -47,7 +47,7 @@ function M.build(pos)
     end
   end
 
-  local test_cmd, json_filepath = cmd.build_test_command_for_dir(module_name)
+  local test_cmd, json_filepath = cmd.test_command_for_dir(module_name)
 
   --- @type neotest.RunSpec
   local run_spec = {

--- a/lua/neotest-golang/runspec_dir.lua
+++ b/lua/neotest-golang/runspec_dir.lua
@@ -1,7 +1,6 @@
 --- Helpers to build the command and context around running all tests of
 --- a Go module.
 
-local json = require("neotest-golang.json")
 local cmd = require("neotest-golang.cmd")
 
 local M = {}

--- a/lua/neotest-golang/runspec_dir.lua
+++ b/lua/neotest-golang/runspec_dir.lua
@@ -27,7 +27,7 @@ function M.build(pos)
       command = { "echo", msg },
       context = {
         id = pos.id,
-        skip = true,
+        test_execution_skipped = true,
         pos_type = "dir",
       },
     }

--- a/lua/neotest-golang/runspec_dir.lua
+++ b/lua/neotest-golang/runspec_dir.lua
@@ -35,8 +35,7 @@ function M.build(pos)
   end
 
   local go_mod_folderpath = vim.fn.fnamemodify(go_mod_filepath, ":h")
-  local go_list_command = cmd.golist_cmd(go_mod_folderpath)
-  local golist_output = json.process_golist_output(go_list_command)
+  local golist_output = cmd.golist_output(go_mod_folderpath)
 
   -- find the go module that corresponds to the go_mod_folderpath
   local module_name = "./..." -- if no go module, run all tests at the $CWD

--- a/lua/neotest-golang/runspec_file.lua
+++ b/lua/neotest-golang/runspec_file.lua
@@ -14,7 +14,7 @@ function M.build(pos, tree)
       command = { "echo", "No tests found in file" },
       context = {
         id = pos.id,
-        skip = true,
+        test_execution_skipped = true,
         pos_type = "test", -- TODO: to be implemented as "file" later
       },
     }

--- a/lua/neotest-golang/runspec_test.lua
+++ b/lua/neotest-golang/runspec_test.lua
@@ -23,31 +23,10 @@ function M.build(pos, strategy)
   local test_name = convert.to_gotest_test_name(pos.id)
   test_name = convert.to_gotest_regex_pattern(test_name)
 
-  --- The runner to use for running tests.
-  --- @type string
-  local runner = options.get().runner
-
-  -- TODO: if gotestsum, check if it is on $PATH, or fall back onto `go test`
-
-  --- The filepath to write test output JSON to, if using `gotestsum`.
-  --- @type string | nil
-  local json_filepath = nil
-
-  --- The final test command to execute.
-  --- @type table<string>
-  local test_cmd = {}
-
-  if runner == "go" then
-    test_cmd =
-      cmd.build_gotest_cmd_for_test(test_folder_absolute_path, test_name)
-  elseif runner == "gotestsum" then
-    json_filepath = vim.fs.normalize(async.fn.tempname())
-    test_cmd = cmd.build_gotestsum_cmd_for_test(
-      test_folder_absolute_path,
-      test_name,
-      json_filepath
-    )
-  end
+  local test_cmd, json_filepath = cmd.build_test_command_for_individual_test(
+    test_folder_absolute_path,
+    test_name
+  )
 
   local runspec_strategy = nil
   if strategy == "dap" then

--- a/lua/neotest-golang/runspec_test.lua
+++ b/lua/neotest-golang/runspec_test.lua
@@ -15,8 +15,7 @@ local M = {}
 function M.build(pos, strategy)
   --- @type string
   local test_folder_absolute_path = string.match(pos.path, "(.+)/")
-  local go_list_command = cmd.golist_cmd(test_folder_absolute_path)
-  local golist_output = json.process_golist_output(go_list_command)
+  local golist_output = cmd.golist_output(test_folder_absolute_path)
 
   --- @type string
   local test_name = convert.to_gotest_test_name(pos.id)

--- a/lua/neotest-golang/runspec_test.lua
+++ b/lua/neotest-golang/runspec_test.lua
@@ -37,36 +37,10 @@ function M.build(pos, strategy)
     end
   end
 
-  return M.build_runspec(
-    pos,
-    test_folder_absolute_path,
-    test_cmd,
-    golist_output,
-    json_filepath,
-    runspec_strategy
-  )
-end
-
---- Build runspec for a directory of tests
---- @param pos neotest.Position
---- @param cwd string
---- @param test_cmd table<string>
---- @param golist_output table
---- @param json_filepath string | nil
---- @param runspec_strategy table | nil
---- @return neotest.RunSpec | neotest.RunSpec[] | nil
-function M.build_runspec(
-  pos,
-  cwd,
-  test_cmd,
-  golist_output,
-  json_filepath,
-  runspec_strategy
-)
   --- @type neotest.RunSpec
   local run_spec = {
     command = test_cmd,
-    cwd = cwd,
+    cwd = test_folder_absolute_path,
     context = {
       id = pos.id,
       test_filepath = pos.path,

--- a/lua/neotest-golang/runspec_test.lua
+++ b/lua/neotest-golang/runspec_test.lua
@@ -53,7 +53,7 @@ function M.build(pos, strategy)
 
   if runspec_strategy ~= nil then
     run_spec.strategy = runspec_strategy
-    run_spec.context.skip = true
+    run_spec.context.debug_and_skip = true
   end
 
   return run_spec

--- a/lua/neotest-golang/runspec_test.lua
+++ b/lua/neotest-golang/runspec_test.lua
@@ -50,7 +50,7 @@ function M.build(pos, strategy)
   }
 
   if json_filepath ~= nil then
-    run_spec.context.jsonfile = json_filepath
+    run_spec.context.json_filepath = json_filepath
   end
 
   if runspec_strategy ~= nil then

--- a/lua/neotest-golang/runspec_test.lua
+++ b/lua/neotest-golang/runspec_test.lua
@@ -1,7 +1,5 @@
 --- Helpers to build the command and context around running a single test.
 
-local async = require("neotest.async")
-
 local convert = require("neotest-golang.convert")
 local options = require("neotest-golang.options")
 local json = require("neotest-golang.json")

--- a/lua/neotest-golang/runspec_test.lua
+++ b/lua/neotest-golang/runspec_test.lua
@@ -15,17 +15,15 @@ local M = {}
 function M.build(pos, strategy)
   --- @type string
   local test_folder_absolute_path = string.match(pos.path, "(.+)/")
-  local go_list_command = cmd.build_golist_cmd(test_folder_absolute_path)
+  local go_list_command = cmd.golist_cmd(test_folder_absolute_path)
   local golist_output = json.process_golist_output(go_list_command)
 
   --- @type string
   local test_name = convert.to_gotest_test_name(pos.id)
   test_name = convert.to_gotest_regex_pattern(test_name)
 
-  local test_cmd, json_filepath = cmd.build_test_command_for_individual_test(
-    test_folder_absolute_path,
-    test_name
-  )
+  local test_cmd, json_filepath =
+    cmd.test_command_for_individual_test(test_folder_absolute_path, test_name)
 
   local runspec_strategy = nil
   if strategy == "dap" then

--- a/tests/unit/options_spec.lua
+++ b/tests/unit/options_spec.lua
@@ -5,11 +5,13 @@ describe("Options are set up", function()
     local expected_options = {
       dap_go_enabled = false,
       dap_go_opts = {},
+      runner = "go",
       go_test_args = {
         "-v",
         "-race",
         "-count=1",
       },
+      gotestsum_args = { "--format=standard-verbose" },
       warn_test_name_dupes = true,
       warn_test_not_executed = true,
       dev_notifications = false,
@@ -22,12 +24,14 @@ describe("Options are set up", function()
     local expected_options = {
       dap_go_enabled = false,
       dap_go_opts = {},
+      runner = "go",
       go_test_args = {
         "-v",
         "-race",
         "-count=1",
         "-parallel=1", -- non-default
       },
+      gotestsum_args = { "--format=standard-verbose" },
       warn_test_name_dupes = true,
       warn_test_not_executed = true,
       dev_notifications = false,


### PR DESCRIPTION
![image](https://github.com/fredrikaverpil/neotest-golang/assets/994357/2950b110-0c89-4daa-ab55-74dabad56f50)


This is just me playing around with using `gotestsum` so output is readable when attaching to long-running test (hotkey `a` in the test summary window), like an entire test suite.

This can allow nice output to be shown (when attached) as tests are running. Under the hood, neotest-golang will still  parse the JSON output.

To do:
- Clean up and refactoring, so command arguments can be controlled nicely and intuitively.
- If `gotestsum` is chosen as "test runner", verify it indeed is on `$PATH` or throw error (possibly fall back to `go test`).