### PR TITLE
fix: search for go.mod up until home folder

### DIFF
--- a/lua/neotest-golang/path.lua
+++ b/lua/neotest-golang/path.lua
@@ -10,7 +10,7 @@ function M.find_file_upwards(filename, start_path)
   local scan = require("plenary.scandir")
   local cwd = vim.fn.getcwd()
   local found_filepath = nil
-  while start_path ~= cwd do
+  while start_path ~= vim.fn.expand("$HOME") do
     local files = scan.scan_dir(
       start_path,
       { search_pattern = filename, hidden = true, depth = 1 }


### PR DESCRIPTION
Fix #103

```lua
  {
    "nvim-neotest/neotest",
    ft = { "go" },
    dependencies = {
      {
        "fredrikaverpil/neotest-golang",
        branch = "fix/expand-upwards-search",  -- ADD THIS
      },
    },
    opts = function(_, opts)
      opts.adapters = opts.adapters or {}
      opts.adapters["neotest-golang"] = {
        dap_go_enabled = true,
      }
    end,
  },
```