### PR TITLE
feat: add logger

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/configuration.yml
+++ b/.github/DISCUSSION_TEMPLATE/configuration.yml
@@ -18,6 +18,8 @@ body:
           required: true
         - label: I have updated to the latest version of neotest-golang.
           required: true
+        - label: I have checked the Neotest log for errors (see README for instructions on enabling it).
+          required: false
   - type: input
     attributes:
       label: "Neovim version (nvim -v)"

--- a/README.md
+++ b/README.md
@@ -75,14 +75,13 @@ You can run `:checkhealth neotest-golang` to review common issues.
 
 ## ⚙️ Configuration
 
-| Argument                 | Default value                   | Description                                                                                                                                                          |
-| ------------------------ | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `go_test_args`           | `{ "-v", "-race", "-count=1" }` | Arguments to pass into `go test`.                                                                                                                                    |
-| `dap_go_enabled`         | `false`                         | Leverage [leoluz/nvim-dap-go](https://github.com/leoluz/nvim-dap-go) for debugging tests.                                                                            |
-| `dap_go_opts`            | `{}`                            | Options to pass into `require("dap-go").setup()`.                                                                                                                    |
-| `testify_enabled`        | `false`                         | Enable support for [testify](https://github.com/stretchr/testify) suites. See [here](https://github.com/fredrikaverpil/neotest-golang#testify-suites) for more info. |
-| `warn_test_name_dupes`   | `true`                          | Warn about duplicate test names within the same Go package.                                                                                                          |
-| `warn_test_not_executed` | `true`                          | Warn if test was not executed.                                                                                                                                       |
+| Argument               | Default value                   | Description                                                                                                                                                          |
+| ---------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `go_test_args`         | `{ "-v", "-race", "-count=1" }` | Arguments to pass into `go test`.                                                                                                                                    |
+| `dap_go_enabled`       | `false`                         | Leverage [leoluz/nvim-dap-go](https://github.com/leoluz/nvim-dap-go) for debugging tests.                                                                            |
+| `dap_go_opts`          | `{}`                            | Options to pass into `require("dap-go").setup()`.                                                                                                                    |
+| `testify_enabled`      | `false`                         | Enable support for [testify](https://github.com/stretchr/testify) suites. See [here](https://github.com/fredrikaverpil/neotest-golang#testify-suites) for more info. |
+| `warn_test_name_dupes` | `true`                          | Warn about duplicate test names within the same Go package.                                                                                                          |
 
 ### Example configuration: custom `go test` arguments
 
@@ -303,11 +302,24 @@ return {
 
 ## ⛑️ Tips & troubleshooting
 
-### Issues with setting up the adapter
+### Issues with setting up or using the adapter
 
 You can run `:checkhealth neotest-golang` to review common issues. If you need
 help, please open a discussion
 [here](https://github.com/fredrikaverpil/neotest-golang/discussions/new?category=configuration).
+
+You can also enable logging to further inspect what's going on under the hood.
+Neotest-golang piggybacks on the Neotest logger. You can enable it like so:
+
+```lua
+require("neotest.logging"):set_level(vim.log.levels.INFO)
+```
+
+Lower the log level further to `DEBUG` or `TRACE` to get even more information.
+
+You can get ahold of the log file's path using
+`require("neotest.logging"):get_filename()`, which usually points to your
+`~/.local/state/nvim/neotest.log`.
 
 ### Neotest is slowing down Neovim
 

--- a/lua/neotest-golang/features/testify/tree_modification.lua
+++ b/lua/neotest-golang/features/testify/tree_modification.lua
@@ -1,6 +1,6 @@
 --- Functions to modify the Neotest tree, for testify suite support.
 
-local options = require("neotest-golang.options")
+local logger = require("neotest-golang.logging")
 local lib = require("neotest-golang.lib")
 local lookup = require("neotest-golang.features.testify.lookup")
 
@@ -40,9 +40,8 @@ function M.modify_neotest_tree(file_path, tree)
   end
 
   if not lookup_table then
-    vim.notify(
-      "No lookup found. Could not modify Neotest tree for testify suite support",
-      vim.log.levels.WARN
+    logger.warn(
+      "No lookup found. Could not modify Neotest tree for testify suite support"
     )
     return tree
   end

--- a/lua/neotest-golang/init.lua
+++ b/lua/neotest-golang/init.lua
@@ -1,11 +1,11 @@
 --- This is the main entry point for the neotest-golang adapter. It follows the
 --- Neotest interface: https://github.com/nvim-neotest/neotest/blob/master/lua/neotest/adapters/interface.lua
 
+local logger = require("neotest-golang.logging")
 local options = require("neotest-golang.options")
 local query = require("neotest-golang.query")
 local runspec = require("neotest-golang.runspec")
 local process = require("neotest-golang.process")
-local testify = require("neotest-golang.features.testify")
 
 local M = {}
 
@@ -72,10 +72,7 @@ function M.Adapter.build_spec(args)
   local pos = args.tree:data() -- NOTE: causes <file> is not accessible by the current user!
 
   if not tree then
-    vim.notify(
-      "Unexpectedly did not receive a neotest.Tree.",
-      vim.log.levels.ERROR
-    )
+    logger.error("Unexpectedly did not receive a neotest.Tree.")
     return
   end
 
@@ -123,11 +120,10 @@ function M.Adapter.build_spec(args)
     return runspec.test.build(pos, args.strategy)
   end
 
-  vim.notify(
+  logger.error(
     "Unknown Neotest position type, "
       .. "cannot build runspec with position type: "
-      .. pos.type,
-    vim.log.levels.ERROR
+      .. pos.type
   )
 end
 
@@ -165,10 +161,9 @@ function M.Adapter.results(spec, result, tree)
     return results
   end
 
-  vim.notify(
+  logger.error(
     "Cannot process test results due to unknown Neotest position type:"
-      .. spec.context.pos_type,
-    vim.log.levels.ERROR
+      .. spec.context.pos_type
   )
 end
 

--- a/lua/neotest-golang/lib/cmd.lua
+++ b/lua/neotest-golang/lib/cmd.lua
@@ -2,6 +2,7 @@
 
 local async = require("neotest.async")
 
+local logger = require("neotest-golang.logging")
 local options = require("neotest-golang.options")
 local json = require("neotest-golang.lib.json")
 
@@ -52,6 +53,8 @@ function M.test_command(go_test_required_args)
     cmd = M.gotestsum(go_test_required_args, json_filepath)
   end
 
+  logger.info("Test command: " .. table.concat(cmd, " "))
+
   return cmd, json_filepath
 end
 
@@ -81,7 +84,7 @@ end
 
 function M.system_has(executable)
   if vim.fn.executable(executable) == 0 then
-    vim.notify("Executable not found: " .. executable, vim.log.levels.WARN)
+    logger.warn("Executable not found: " .. executable)
     return false
   end
   return true

--- a/lua/neotest-golang/lib/json.lua
+++ b/lua/neotest-golang/lib/json.lua
@@ -1,5 +1,7 @@
 --- JSON processing helpers.
 
+local logger = require("neotest-golang.logging")
+
 local M = {}
 
 --- Decode JSON from a table of strings into a table of objects.
@@ -14,7 +16,7 @@ function M.decode_from_table(tbl)
         table.insert(jsonlines, json_data)
       else
         -- NOTE: this can be hit because of "Vim:E474: Unidentified byte: ..."
-        vim.notify("Failed to decode JSON line: " .. line, vim.log.levels.WARN)
+        logger.warn("Failed to decode JSON line: " .. line)
       end
     else
       -- vim.notify("Not valid JSON: " .. line, vim.log.levels.DEBUG)

--- a/lua/neotest-golang/logging.lua
+++ b/lua/neotest-golang/logging.lua
@@ -1,0 +1,35 @@
+local M = {}
+
+---@type neotest.Logger
+local logger = require("neotest.logging")
+
+local prefix = "[neotest-golang] "
+
+---@param msg string
+function M.trace(msg)
+  return logger.trace(prefix .. msg)
+end
+
+---@param msg string
+function M.debug(msg)
+  logger.debug(prefix .. msg)
+end
+
+---@param msg string
+function M.info(msg)
+  logger.info(prefix .. msg)
+end
+
+---@param msg string
+function M.warn(msg)
+  vim.notify(msg, vim.log.levels.WARN)
+  logger.warn(prefix .. msg)
+end
+
+---@param msg string
+function M.error(msg)
+  vim.notify(msg, vim.log.levels.ERROR)
+  logger.error(prefix .. msg)
+end
+
+return M

--- a/lua/neotest-golang/options.lua
+++ b/lua/neotest-golang/options.lua
@@ -10,7 +10,6 @@ local opts = {
   dap_go_opts = {},
   testify_enabled = false,
   warn_test_name_dupes = true,
-  warn_test_not_executed = true,
 
   -- experimental, for now undocumented, options
   runner = "go", -- or "gotestsum"

--- a/lua/neotest-golang/process.lua
+++ b/lua/neotest-golang/process.lua
@@ -3,6 +3,7 @@
 
 local async = require("neotest.async")
 
+local logger = require("neotest-golang.logging")
 local options = require("neotest-golang.options")
 local lib = require("neotest-golang.lib")
 
@@ -59,9 +60,8 @@ function M.test_results(spec, result, tree)
   -- Sanity check
   if options.get().dev_notifications == true then
     if pos.id ~= context.pos_id then
-      vim.notify(
-        "Neotest position id mismatch: " .. pos.id .. " vs " .. context.pos_id,
-        vim.log.levels.ERROR
+      logger.error(
+        "Neotest position id mismatch: " .. pos.id .. " vs " .. context.pos_id
       )
     end
   end
@@ -118,7 +118,7 @@ function M.test_results(spec, result, tree)
   local res = M.aggregate_data(tree, gotest_output, golist_output)
 
   -- DEBUG: enable the following to see the internal test result data.
-  -- vim.notify(vim.inspect(res), vim.log.levels.DEBUG)
+  -- logger.debug(vim.inspect(res))
 
   -- show various warnings
   M.show_warnings(res)
@@ -130,7 +130,7 @@ function M.test_results(spec, result, tree)
   end
 
   -- DEBUG: enable the following to see the final Neotest result.
-  -- vim.notify(vim.inspect(neotest_results), vim.log.levels.DEBUG)
+  -- logger.debug(vim.inspect(neotest_results))
 
   return neotest_result
 end
@@ -322,11 +322,10 @@ function M.show_warnings(d)
       end
     end
     if #position_ids > 0 then
-      vim.notify(
-        "Test(s) not associated (not found/executed):\n"
-          .. table.concat(position_ids, "\n"),
-        vim.log.levels.DEBUG
-      )
+      local msg = "Test(s) not associated (not found/executed):\n"
+        .. table.concat(position_ids, "\n")
+      vim.notify(msg, vim.log.levels.DEBUG)
+      logger.debug(msg)
     end
   end
 
@@ -342,9 +341,8 @@ function M.show_warnings(d)
       end
     end
     if #test_dupes > 0 then
-      vim.notify(
-        "Duplicate test name(s) detected:\n" .. table.concat(test_dupes, "\n"),
-        vim.log.levels.WARN
+      logger.warn(
+        "Duplicate test name(s) detected:\n" .. table.concat(test_dupes, "\n")
       )
     end
   end

--- a/lua/neotest-golang/runspec/dir.lua
+++ b/lua/neotest-golang/runspec/dir.lua
@@ -1,6 +1,7 @@
 --- Helpers to build the command and context around running all tests of
 --- a Go package.
 
+local logger = require("neotest-golang.logging")
 local lib = require("neotest-golang.lib")
 
 local M = {}
@@ -61,7 +62,7 @@ end
 function M.fail_fast(pos)
   local msg = "The selected folder must contain a go.mod file "
     .. "or be a subdirectory of a Go package."
-  vim.notify(msg, vim.log.levels.ERROR)
+  logger.error(msg)
 
   --- @type RunspecContext
   local context = {

--- a/tests/unit/options_spec.lua
+++ b/tests/unit/options_spec.lua
@@ -13,7 +13,6 @@ describe("Options are set up", function()
       dap_go_opts = {},
       testify_enabled = false,
       warn_test_name_dupes = true,
-      warn_test_not_executed = true,
 
       -- experimental
       runner = "go",
@@ -36,7 +35,6 @@ describe("Options are set up", function()
       dap_go_opts = {},
       testify_enabled = false,
       warn_test_name_dupes = true,
-      warn_test_not_executed = true,
 
       -- experimental
       runner = "go",


### PR DESCRIPTION
After having [given this some thought](https://github.com/nvim-neotest/neotest/discussions/422), I'm adding a logger which piggybacks on / reuses the neotest logger.

This also removes the unused option `warn_test_not_executed`.