### PR TITLE
fix(dap): show config error, remove excessive regex characters from test name

### DIFF
--- a/lua/neotest-golang/features/dap/init.lua
+++ b/lua/neotest-golang/features/dap/init.lua
@@ -4,6 +4,8 @@ local options = require("neotest-golang.options")
 
 local M = {}
 
+---This will prepare and setup nvim-dap-go for debugging.
+---@param cwd string
 function M.setup_debugging(cwd)
   local dap_go_opts = options.get().dap_go_opts or {}
   local dap_go_opts_original = vim.deepcopy(dap_go_opts)

--- a/lua/neotest-golang/features/dap/init.lua
+++ b/lua/neotest-golang/features/dap/init.lua
@@ -21,9 +21,9 @@ function M.setup_debugging(cwd)
   end
 end
 
---- @param test_name string
+--- @param test_name_regex string
 --- @return table | nil
-function M.get_dap_config(test_name)
+function M.get_dap_config(test_name_regex)
   -- :help dap-configuration
   local dap_config = {
     type = "go",
@@ -31,7 +31,7 @@ function M.get_dap_config(test_name)
     request = "launch",
     mode = "test",
     program = "${fileDirname}",
-    args = { "-test.run", "^" .. test_name .. "$" },
+    args = { "-test.run", test_name_regex },
   }
 
   return dap_config

--- a/lua/neotest-golang/runspec/test.lua
+++ b/lua/neotest-golang/runspec/test.lua
@@ -18,17 +18,17 @@ function M.build(pos, strategy)
 
   --- @type string
   local test_name = lib.convert.to_gotest_test_name(pos.id)
-  test_name = lib.convert.to_gotest_regex_pattern(test_name)
+  local test_name_regex = lib.convert.to_gotest_regex_pattern(test_name)
 
   local test_cmd, json_filepath = lib.cmd.test_command_in_package_with_regexp(
     test_folder_absolute_path,
-    test_name
+    test_name_regex
   )
 
   local runspec_strategy = nil
   if strategy == "dap" then
     M.assert_dap_prerequisites()
-    runspec_strategy = dap.get_dap_config(test_name)
+    runspec_strategy = dap.get_dap_config(test_name_regex)
     logger.debug("DAP strategy used: " .. vim.inspect(runspec_strategy))
     dap.setup_debugging(test_folder_absolute_path)
   end

--- a/lua/neotest-golang/runspec/test.lua
+++ b/lua/neotest-golang/runspec/test.lua
@@ -1,5 +1,6 @@
 --- Helpers to build the command and context around running a single test.
 
+local logger = require("neotest-golang.logging")
 local lib = require("neotest-golang.lib")
 local options = require("neotest-golang.options")
 local dap = require("neotest-golang.features.dap")
@@ -26,10 +27,10 @@ function M.build(pos, strategy)
 
   local runspec_strategy = nil
   if strategy == "dap" then
-    if options.get().dap_go_enabled then
-      runspec_strategy = dap.get_dap_config(test_name)
-      dap.setup_debugging(test_folder_absolute_path)
-    end
+    M.assert_dap_prerequisites()
+    runspec_strategy = dap.get_dap_config(test_name)
+    logger.debug("DAP strategy used: " .. vim.inspect(runspec_strategy))
+    dap.setup_debugging(test_folder_absolute_path)
   end
 
   --- @type RunspecContext
@@ -54,6 +55,17 @@ function M.build(pos, strategy)
   end
 
   return run_spec
+end
+
+function M.assert_dap_prerequisites()
+  local dap_go_enabled = options.get().dap_go_enabled
+  local dap_go_found = pcall(require, "dap-go")
+  if not dap_go_enabled or not dap_go_found then
+    local msg = "You must set {dap_go_enabled=true} and have leoluz/nvim-dap-go installed to use DAP strategy. "
+      .. "See the neotest-golang README for more information."
+    logger.error(msg)
+    error(msg)
+  end
 end
 
 return M


### PR DESCRIPTION
- **fix: show better error when DAP is not configured properly** (related to https://github.com/fredrikaverpil/neotest-golang/discussions/140)
- **fix: regex characters applied twice**
