### PR TITLE
chore: remove option required to enable dap

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ You can run `:checkhealth neotest-golang` to review common issues.
 | Argument                 | Default value                   | Description                                                                                                                                                          |
 | ------------------------ | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `go_test_args`           | `{ "-v", "-race", "-count=1" }` | Arguments to pass into `go test`.                                                                                                                                    |
-| `dap_go_enabled`         | `false`                         | Leverage [leoluz/nvim-dap-go](https://github.com/leoluz/nvim-dap-go) for debugging tests.                                                                            |
 | `dap_go_opts`            | `{}`                            | Options to pass into `require("dap-go").setup()`.                                                                                                                    |
 | `testify_enabled`        | `false`                         | Enable support for [testify](https://github.com/stretchr/testify) suites. See [here](https://github.com/fredrikaverpil/neotest-golang#testify-suites) for more info. |
 | `warn_test_name_dupes`   | `true`                          | Warn about duplicate test names within the same Go package.                                                                                                          |
@@ -113,17 +112,42 @@ See `go help test`, `go help testflag`, `go help build` for possible arguments.
 To debug tests, make sure you depend on
 [mfussenegger/nvim-dap](https://github.com/mfussenegger/nvim-dap),
 [rcarriga/nvim-dap-ui](https://github.com/rcarriga/nvim-dap-ui) and
-[leoluz/nvim-dap-go](https://github.com/leoluz/nvim-dap-go).
+[leoluz/nvim-dap-go](https://github.com/leoluz/nvim-dap-go). For example, make
+the following changes to your lua setup:
 
-Then set `dap_go_enabled` to `true`:
-
-```lua
-local config = { dap_go_enabled = true } -- Specify configuration
-require("neotest").setup({
-  adapters = {
-    require("neotest-golang")(config), -- Apply configuration
+```diff
+return {
++  {
++    "rcarriga/nvim-dap-ui",
++    dependencies = {
++      "mfussenegger/nvim-dap",
++      "nvim-neotest/nvim-nio",
++    },
++  },
+  {
+    "nvim-neotest/neotest",
+    dependencies = {
+      "nvim-neotest/nvim-nio",
+      "nvim-lua/plenary.nvim",
+      "antoinemadec/FixCursorHold.nvim",
+      "nvim-treesitter/nvim-treesitter",
+-      "fredrikaverpil/neotest-golang", -- Installation
++      {
++        "fredrikaverpil/neotest-golang", -- Installation
++        dependencies = {
++          "leoluz/nvim-dap-go",
++        },
++      },
+    },
+    config = function()
+      require("neotest").setup({
+        adapters = {
+          require("neotest-golang"), -- Registration
+        },
+      })
+    end,
   },
-})
+}
 ```
 
 Finally, set a keymap, like:
@@ -153,7 +177,13 @@ return {
 
 ```lua
 return {
-  -- Neotest setup
+  {
+    "rcarriga/nvim-dap-ui",
+    dependencies = {
+      "mfussenegger/nvim-dap",
+      "nvim-neotest/nvim-nio",
+    },
+  },
   {
     "nvim-neotest/neotest",
     event = "VeryLazy",
@@ -185,7 +215,6 @@ return {
           "-race",
           "-coverprofile=" .. vim.fn.getcwd() .. "/coverage.out",
         },
-        dap_go_enabled = true,
       }
     end,
     config = function(_, opts)

--- a/lua/neotest-golang/options.lua
+++ b/lua/neotest-golang/options.lua
@@ -8,7 +8,6 @@ local M = {}
 
 local opts = {
   go_test_args = { "-v", "-race", "-count=1" },
-  dap_go_enabled = false,
   dap_go_opts = {},
   testify_enabled = false,
   warn_test_name_dupes = true,

--- a/lua/neotest-golang/runspec/test.lua
+++ b/lua/neotest-golang/runspec/test.lua
@@ -58,10 +58,9 @@ function M.build(pos, strategy)
 end
 
 function M.assert_dap_prerequisites()
-  local dap_go_enabled = options.get().dap_go_enabled
   local dap_go_found = pcall(require, "dap-go")
-  if not dap_go_enabled or not dap_go_found then
-    local msg = "You must set {dap_go_enabled=true} and have leoluz/nvim-dap-go installed to use DAP strategy. "
+  if not dap_go_found then
+    local msg = "You must have leoluz/nvim-dap-go installed to use DAP strategy. "
       .. "See the neotest-golang README for more information."
     logger.error(msg)
     error(msg)

--- a/tests/unit/options_spec.lua
+++ b/tests/unit/options_spec.lua
@@ -9,7 +9,6 @@ describe("Options are set up", function()
         "-race",
         "-count=1",
       },
-      dap_go_enabled = false,
       dap_go_opts = {},
       testify_enabled = false,
       warn_test_name_dupes = true,
@@ -32,7 +31,6 @@ describe("Options are set up", function()
         "-count=1",
         "-parallel=1", -- non-default
       },
-      dap_go_enabled = false,
       dap_go_opts = {},
       testify_enabled = false,
       warn_test_name_dupes = true,


### PR DESCRIPTION
It's sufficient to just make sure to have the dap-go plugin installed.

If the plugin is not installed, this will be shown in `:checkhealth neotest-golang` and as an error notification in Neovim if you try to debug a test.

This is technically not breaking backwards compatibility but will leave an unused option dangling in user configs. I could add a warning that will pop up about this, but I'm not sure it's really that important and worthy of the noise...
