### PR TITLE
feat: gotestsum

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,14 +158,16 @@ consider setting up neotest and its adapters in a
 
 ## ⚙️ Configuration
 
-| Argument                 | Default value                   | Description                                                                                                                                                                                                                                                        |
-| ------------------------ | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `go_test_args`           | `{ "-v", "-race", "-count=1" }` | Arguments to pass into `go test`. Note: [`-tags` usage](https://github.com/fredrikaverpil/neotest-golang#using-build-tags), [pass args as function](https://github.com/fredrikaverpil/neotest-golang#pass-arguments-as-function-instead-of-table).                 |
-| `go_list_args`           | `{}`                            | Arguments to pass into `go list`. Note: [`-tags` usage](https://github.com/fredrikaverpil/neotest-golang#using-build-tags), [pass args as function](https://github.com/fredrikaverpil/neotest-golang#pass-arguments-as-function-instead-of-table).                 |
-| `dap_go_opts`            | `{}`                            | Options to pass into `require("dap-go").setup()`. Note: [`-tags` usage](https://github.com/fredrikaverpil/neotest-golang#using-build-tags), [pass args as function](https://github.com/fredrikaverpil/neotest-golang#pass-arguments-as-function-instead-of-table). |
-| `testify_enabled`        | `false`                         | Enable support for [testify](https://github.com/stretchr/testify) suites. See [here](https://github.com/fredrikaverpil/neotest-golang#testify-suites) for more info.                                                                                               |
-| `warn_test_name_dupes`   | `true`                          | Warn about duplicate test names within the same Go package.                                                                                                                                                                                                        |
-| `warn_test_not_executed` | `true`                          | Warn if test was not executed.                                                                                                                                                                                                                                     |
+| Argument                 | Default value                     | Description                                                                                                                                                                                                                                                                                                                          |
+| ------------------------ | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `runner`                 | `go`                              | Defines the test runner. Valid values: `go` or `gotestsum`.                                                                                                                                                                                                                                                                          |
+| `go_test_args`           | `{ "-v", "-race", "-count=1" }`   | Arguments to pass into `go test`. Note: [`-tags` usage](https://github.com/fredrikaverpil/neotest-golang#using-build-tags), [pass args as function](https://github.com/fredrikaverpil/neotest-golang#pass-arguments-as-function-instead-of-table).                                                                                   |
+| `gotestsum_args`         | `{ "--format=standard-verbose" }` | Arguments to pass into `gotestsum`. Notes: [`-tags` usage](https://github.com/fredrikaverpil/neotest-golang#using-build-tags), [pass args as function](https://github.com/fredrikaverpil/neotest-golang#pass-arguments-as-function-instead-of-table). Will only be used if `runner = "gotestsum"`. The `go_test_args` still applies. |
+| `go_list_args`           | `{}`                              | Arguments to pass into `go list`. Note: [`-tags` usage](https://github.com/fredrikaverpil/neotest-golang#using-build-tags), [pass args as function](https://github.com/fredrikaverpil/neotest-golang#pass-arguments-as-function-instead-of-table).                                                                                   |
+| `dap_go_opts`            | `{}`                              | Options to pass into `require("dap-go").setup()`. Note: [`-tags` usage](https://github.com/fredrikaverpil/neotest-golang#using-build-tags), [pass args as function](https://github.com/fredrikaverpil/neotest-golang#pass-arguments-as-function-instead-of-table).                                                                   |
+| `testify_enabled`        | `false`                           | Enable support for [testify](https://github.com/stretchr/testify) suites. See [here](https://github.com/fredrikaverpil/neotest-golang#testify-suites) for more info.                                                                                                                                                                 |
+| `warn_test_name_dupes`   | `true`                            | Warn about duplicate test names within the same Go package.                                                                                                                                                                                                                                                                          |
+| `warn_test_not_executed` | `true`                            | Warn if test was not executed.                                                                                                                                                                                                                                                                                                       |
 
 ### Example configuration: custom `go test` arguments
 
@@ -256,6 +258,43 @@ return {
 ```
 
 For a more verbose example, see the "extra everything" example config.
+
+### Use `gotestsum` as test runner
+
+To improve reliability, you can choose to run tests using
+[`gotestsum`](https://github.com/gotestyourself/gotestsum) as the test runner.
+This tool allows you to use one format for stdout while simultaneously writing
+test output to a JSON file. `gotestsum` actually calls `go test` behind the
+scenes, so your `go_test_args` configuration remains valid and will still apply.
+Using `gotestsum` offers the following benefits:
+
+- When you "attach" to a running test, you'll see clean `go test` output instead
+  of having to navigate through difficult-to-read JSON.
+- On certain platforms or terminals, there's a risk of ANSI codes or other
+  characters being seemingly randomly inserted into the JSON test output. This
+  can corrupt the data and cause problems with JSON decoding. Enabling
+  `gotestsum` eliminates these issues.
+
+Make the `gotestsum` command availalbe via
+[mason.nvim](https://github.com/williamboman/mason.nvim) or by running the
+following in your shell:
+
+```bash
+go install gotest.tools/gotestsum@latest
+```
+
+Then add the required configuration:
+
+```lua
+local config = { -- Specify configuration
+  runner = "gotestsum"
+}
+require("neotest").setup({
+  adapters = {
+    require("neotest-golang")(config), -- Apply configuration
+  },
+})
+```
 
 ### Example configuration: extra everything
 

--- a/lua/neotest-golang/health.lua
+++ b/lua/neotest-golang/health.lua
@@ -25,6 +25,9 @@ function M.check()
   M.is_plugin_available("dap")
   M.is_plugin_available("dapui")
   M.is_plugin_available("dap-go")
+
+  start("Gotestsum (optional)")
+  M.binary_found_on_path("gotestsum")
 end
 
 function M.binary_found_on_path(executable)

--- a/lua/neotest-golang/options.lua
+++ b/lua/neotest-golang/options.lua
@@ -7,7 +7,9 @@ local logger = require("neotest-golang.logging")
 local M = {}
 
 local opts = {
+  runner = "go", -- or "gotestsum"
   go_test_args = { "-v", "-race", "-count=1" }, -- NOTE: can also be a function
+  gotestsum_args = { "--format=standard-verbose" }, -- NOTE: can also be a function
   go_list_args = {}, -- NOTE: can also be a function
   dap_go_opts = {}, -- NOTE: can also be a function
   testify_enabled = false,
@@ -15,8 +17,6 @@ local opts = {
   warn_test_not_executed = true,
 
   -- experimental, for now undocumented, options
-  runner = "go", -- or "gotestsum"
-  gotestsum_args = { "--format=standard-verbose" }, -- NOTE: can also be a function
   dev_notifications = false,
 }
 

--- a/tests/unit/options_spec.lua
+++ b/tests/unit/options_spec.lua
@@ -4,20 +4,20 @@ local _ = require("plenary")
 describe("Options are set up", function()
   it("With defaults", function()
     local expected_options = {
+      runner = "go",
       go_test_args = {
         "-v",
         "-race",
         "-count=1",
       },
       go_list_args = {},
+      gotestsum_args = { "--format=standard-verbose" },
       dap_go_opts = {},
       testify_enabled = false,
       warn_test_name_dupes = true,
       warn_test_not_executed = true,
 
       -- experimental
-      runner = "go",
-      gotestsum_args = { "--format=standard-verbose" },
       dev_notifications = false,
     }
     options.setup()
@@ -26,6 +26,7 @@ describe("Options are set up", function()
 
   it("With non-defaults", function()
     local expected_options = {
+      runner = "go",
       go_test_args = {
         "-v",
         "-race",
@@ -33,14 +34,13 @@ describe("Options are set up", function()
         "-parallel=1", -- non-default
       },
       go_list_args = {},
+      gotestsum_args = { "--format=standard-verbose" },
       dap_go_opts = {},
       testify_enabled = false,
       warn_test_name_dupes = true,
       warn_test_not_executed = true,
 
       -- experimental
-      runner = "go",
-      gotestsum_args = { "--format=standard-verbose" },
       dev_notifications = false,
     }
     options.setup(expected_options)


### PR DESCRIPTION
This adds documentation around running tests using [`gotestsum`](https://github.com/gotestyourself/gotestsum), which is already implemented in the `main` branch.

My original plan was to research output streaming before exposing the capability of configuring `gotestsum`, because it could end up dictating how the configuration around it would be like. But #149 sped up this process a bit, as it seems like a requirement on Windows with Powershell, hence this PR. However, I'll still keep this in draft for now, as I'm still not 100% sure about how I want `gotestsum` to be configured. There might also be a need to support custom test runners which could affect how configuration around `goteststum` and the default `go` would look like. All in all, this PR adds transparency on the subject.