### PR TITLE
test: integration test for neotest-golang

### DIFF
--- a/tests/integration/neotest_golang_spec.lua
+++ b/tests/integration/neotest_golang_spec.lua
@@ -1,0 +1,24 @@
+local async = require("nio").tests
+local neotest = require("neotest")
+
+describe("neotest-golang integration", function()
+  async.it("runs Go tests and verifies results", function()
+    -- Initialize neotest and set up neotest-golang
+    neotest.setup({
+      adapters = {
+        require("neotest-golang"),
+      },
+    })
+
+    -- Run Go tests in the tests/go directory
+    local results = neotest.run.run({ vim.fn.expand("tests/go") })
+
+    -- Verify the results of the Go tests executed through neotest and neotest-golang
+    for _, result in pairs(results) do
+      assert.are.equal(result.status, "passed")
+    end
+
+    -- Ensure the exit code is 0 and all tests passed
+    assert.are.equal(vim.v.shell_error, 0)
+  end)
+end)


### PR DESCRIPTION
Add integration test for executing Go tests through neotest and neotest-golang.

* **Integration Test**:
  - Create a new file `tests/integration/neotest_golang_spec.lua`.
  - Initialize neotest and set up neotest-golang.
  - Run Go tests in the `tests/go` directory.
  - Verify the results of the Go tests executed through neotest and neotest-golang.
  - Ensure the exit code is 0 and all tests passed.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fredrikaverpil/neotest-golang?shareId=eb67b7ee-7bf0-4214-8704-13a6503a9e1a).