### PR TITLE
fix!: broken 'go list' report on some systems

### DIFF
--- a/lua/neotest-golang/lib/cmd.lua
+++ b/lua/neotest-golang/lib/cmd.lua
@@ -21,7 +21,9 @@ function M.golist_data(cwd)
   local output = vim
     .system(go_list_command, { cwd = cwd, text = true })
     :wait().stdout or ""
-  logger.info({ "Go list output: ", output })
+  if output == "" then
+    logger.error({ "Execution of 'go list' failed, output:", output })
+  end
   return json.decode_from_string(output)
 end
 

--- a/lua/neotest-golang/lib/cmd.lua
+++ b/lua/neotest-golang/lib/cmd.lua
@@ -18,8 +18,9 @@ function M.golist_data(cwd)
   }
   local go_list_command_concat = table.concat(go_list_command, " ")
   logger.debug("Running Go list: " .. go_list_command_concat .. " in " .. cwd)
-  local output =
-    vim.fn.system("cd " .. cwd .. " && " .. go_list_command_concat, " ")
+  local output = vim
+    .system(go_list_command, { cwd = cwd, text = true })
+    :wait().stdout or ""
   logger.info({ "Go list output: ", output })
   return json.decode_from_string(output)
 end


### PR DESCRIPTION
Tests would always be reported as skipped with the "not associated" message.

Not sure how to pinpoint the exact cause of this issue but it happens on my personal setup (WSL Arch with Windows Terminal Canary, if that helps).

`go list` output from log file before this change:

```
...
DEBUG | 2024-08-15T21:36:45Z+0700 | ...uddin/code/neotest-golang/lua/neotest-golang/logging.lua:47 | [neotest-golang] Running Go list: go list -json ./... in /home/miduddin/code/test_go
INFO | 2024-08-15T21:36:45Z+0700 | ...uddin/code/neotest-golang/lua/neotest-golang/logging.lua:59 | [neotest-golang] Go list output:  ]9;9;\\wsl.localhost\arch2\home\miduddin\code\test_go\{ "Dir": "/home/miduddin/code/test_go", "ImportPath": "localhost/testgo", "Name": "main", "Target": "/home/miduddin/.local/share/go/bin/testgo", "Root": "/home/miduddin/code/test_go", "Module": { "Path": "localhost/testgo", "Main": true, "Dir": "/home/miduddin/code/test_go", "GoMod": "/home/miduddin/code/test_go/go.mod", "GoVersion": "1.23.0" }, "Match": [ "./..." ], "Deps": [ "internal/abi", "internal/bytealg", "internal/byteorder", "internal/chacha8rand", "internal/coverage/rtcov", "internal/cpu", "internal/goarch", "internal/godebugs", "internal/goexperiment", "internal/goos", "internal/profilerecord", "internal/runtime/atomic", "internal/runtime/exithook", "internal/runtime/syscall", "internal/stringslite", "runtime", "runtime/internal/math", "runtime/internal/sys", "unsafe" ], "TestGoFiles": [ "main_test.go" ], "TestImports": [ "testing" ] } 
INFO | 2024-08-15T21:36:45Z+0700 | ...uddin/code/neotest-golang/lua/neotest-golang/logging.lua:59 | [neotest-golang] Test command: go test -json -count=1 -race -timeout=10s /home/miduddin/code/test_go -run ^TestStuff$
...
```

After:

```
...
DEBUG | 2024-08-15T21:39:58Z+0700 | ...uddin/code/neotest-golang/lua/neotest-golang/logging.lua:47 | [neotest-golang] Running Go list: go list -json /home/miduddin/code/test_go/...
INFO | 2024-08-15T21:39:58Z+0700 | ...uddin/code/neotest-golang/lua/neotest-golang/logging.lua:59 | [neotest-golang] Go list output:  { "Dir": "/home/miduddin/code/test_go", "ImportPath": "localhost/testgo", "Name": "main", "Target": "/home/miduddin/.local/share/go/bin/testgo", "Root": "/home/miduddin/code/test_go", "Module": { "Path": "localhost/testgo", "Main": true, "Dir": "/home/miduddin/code/test_go", "GoMod": "/home/miduddin/code/test_go/go.mod", "GoVersion": "1.23.0" }, "Match": [ "/home/miduddin/code/test_go/..." ], "Deps": [ "internal/abi", "internal/bytealg", "internal/byteorder", "internal/chacha8rand", "internal/coverage/rtcov", "internal/cpu", "internal/goarch", "internal/godebugs", "internal/goexperiment", "internal/goos", "internal/profilerecord", "internal/runtime/atomic", "internal/runtime/exithook", "internal/runtime/syscall", "internal/stringslite", "runtime", "runtime/internal/math", "runtime/internal/sys", "unsafe" ], "TestGoFiles": [ "main_test.go" ], "TestImports": [ "testing" ] } 
INFO | 2024-08-15T21:39:58Z+0700 | ...uddin/code/neotest-golang/lua/neotest-golang/logging.lua:59 | [neotest-golang] Test command: go test -json -count=1 -race -timeout=10s /home/miduddin/code/test_go -run ^TestStuff$
...
```
---
P.S. Also not sure if this is the best way to fix the issue, but it seems to work on my machine 😁 
Any suggestions would be appreciated.