### PR TITLE
feat: show compilation failure as test output

### DIFF
--- a/lua/neotest-golang/init.lua
+++ b/lua/neotest-golang/init.lua
@@ -135,25 +135,27 @@ end
 --- @param tree neotest.Tree
 --- @return table<string, neotest.Result> | nil
 function M.Adapter.results(spec, result, tree)
-  if spec.context.pos_type == "dir" then
+  local pos = tree:data()
+
+  if pos.type == "dir" then
     -- A test command executed a directory of tests and the output/status must
     -- now be processed.
     local results = process.test_results(spec, result, tree)
     M.workaround_neotest_issue_391(result)
     return results
-  elseif spec.context.pos_type == "file" then
+  elseif pos.type == "file" then
     -- A test command executed a file of tests and the output/status must
     -- now be processed.
     local results = process.test_results(spec, result, tree)
     M.workaround_neotest_issue_391(result)
     return results
-  elseif spec.context.pos_type == "namespace" then
+  elseif pos.type == "namespace" then
     -- A test command executed a namespace and the output/status must now be
     -- processed.
     local results = process.test_results(spec, result, tree)
     M.workaround_neotest_issue_391(result)
     return results
-  elseif spec.context.pos_type == "test" then
+  elseif pos.type == "test" then
     -- A test command executed a single test and the output/status must now be
     -- processed.
     local results = process.test_results(spec, result, tree)
@@ -163,7 +165,7 @@ function M.Adapter.results(spec, result, tree)
 
   logger.error(
     "Cannot process test results due to unknown Neotest position type:"
-      .. spec.context.pos_type
+      .. pos.type
   )
 end
 

--- a/lua/neotest-golang/lib/cmd.lua
+++ b/lua/neotest-golang/lib/cmd.lua
@@ -19,11 +19,21 @@ function M.golist_data(cwd)
   local go_list_command_concat = table.concat(cmd, " ")
   logger.debug("Running Go list: " .. go_list_command_concat .. " in " .. cwd)
   local result = vim.system(cmd, { cwd = cwd, text = true }):wait()
+
+  local err = nil
   if result.code == 1 then
-    logger.error({ "execution of 'go list' failed, output:", result.stderr })
+    err = "go list:"
+    if result.stdout ~= nil and result.stdout ~= "" then
+      err = err .. " " .. result.stdout
+    end
+    if result.stdout ~= nil and result.stderr ~= "" then
+      err = err .. " " .. result.stderr
+    end
+    logger.debug({ "Go list error: ", err })
   end
+
   local output = result.stdout or ""
-  return json.decode_from_string(output)
+  return json.decode_from_string(output), err
 end
 
 function M.test_command_in_package(package_or_path)

--- a/lua/neotest-golang/lib/cmd.lua
+++ b/lua/neotest-golang/lib/cmd.lua
@@ -8,14 +8,10 @@ local json = require("neotest-golang.lib.json")
 
 local M = {}
 
+--- Call 'go list -json {go_list_args...} ./...' to get test file data
+--- @param cwd string
 function M.golist_data(cwd)
-  -- call 'go list -json {go_list_args...} ./...' to get test file data
-
-  -- combine base command, user args and packages(./...)
-  local cmd = { "go", "list", "-json" }
-  vim.list_extend(cmd, options.get().go_list_args or {})
-  vim.list_extend(cmd, { "./..." })
-
+  local cmd = M.golist_command()
   local go_list_command_concat = table.concat(cmd, " ")
   logger.debug("Running Go list: " .. go_list_command_concat .. " in " .. cwd)
   local result = vim.system(cmd, { cwd = cwd, text = true }):wait()
@@ -34,6 +30,13 @@ function M.golist_data(cwd)
 
   local output = result.stdout or ""
   return json.decode_from_string(output), err
+end
+
+function M.golist_command()
+  local cmd = { "go", "list", "-json" }
+  vim.list_extend(cmd, options.get().go_list_args or {})
+  vim.list_extend(cmd, { "./..." })
+  return cmd
 end
 
 function M.test_command_in_package(package_or_path)

--- a/lua/neotest-golang/lib/cmd.lua
+++ b/lua/neotest-golang/lib/cmd.lua
@@ -29,7 +29,10 @@ function M.golist_data(cwd)
   end
 
   local output = result.stdout or ""
-  return json.decode_from_string(output), err
+
+  local golist_output = json.decode_from_string(output)
+  logger.debug({ "JSON-decoded 'go list' output: ", golist_output })
+  return golist_output, err
 end
 
 function M.golist_command()

--- a/lua/neotest-golang/lib/cmd.lua
+++ b/lua/neotest-golang/lib/cmd.lua
@@ -18,10 +18,11 @@ function M.golist_data(cwd)
 
   local go_list_command_concat = table.concat(cmd, " ")
   logger.debug("Running Go list: " .. go_list_command_concat .. " in " .. cwd)
-  local output = vim.system(cmd, { cwd = cwd, text = true }):wait().stdout or ""
-  if output == "" then
-    logger.error({ "Execution of 'go list' failed, output:", output })
+  local result = vim.system(cmd, { cwd = cwd, text = true }):wait()
+  if result.code == 1 then
+    logger.error({ "execution of 'go list' failed, output:", result.stderr })
   end
+  local output = result.stdout or ""
   return json.decode_from_string(output)
 end
 

--- a/lua/neotest-golang/lib/json.lua
+++ b/lua/neotest-golang/lib/json.lua
@@ -6,8 +6,9 @@ local M = {}
 
 --- Decode JSON from a table of strings into a table of objects.
 --- @param tbl table
+--- @param construct_invalid boolean
 --- @return table
-function M.decode_from_table(tbl)
+function M.decode_from_table(tbl, construct_invalid)
   local jsonlines = {}
   for _, line in ipairs(tbl) do
     if string.match(line, "^%s*{") then -- must start with the `{` character
@@ -19,7 +20,11 @@ function M.decode_from_table(tbl)
         logger.warn("Failed to decode JSON line: " .. line)
       end
     else
-      -- vim.notify("Not valid JSON: " .. line, vim.log.levels.DEBUG)
+      logger.debug({ "Not valid JSON:", line })
+      if construct_invalid then
+        -- this is for example errors from stderr, when there is a compilation error
+        table.insert(jsonlines, { Action = "output", Output = line })
+      end
     end
   end
   return jsonlines
@@ -40,7 +45,7 @@ function M.decode_from_string(str)
     current_object = current_object .. line
   end
   table.insert(tbl, current_object)
-  return M.decode_from_table(tbl)
+  return M.decode_from_table(tbl, false)
 end
 
 return M

--- a/lua/neotest-golang/process.lua
+++ b/lua/neotest-golang/process.lua
@@ -101,11 +101,8 @@ function M.test_results(spec, result, tree)
   --- Test command (e.g. 'go test') status.
   --- @type neotest.ResultStatus
   local result_status = nil
-  if
+  if neotest_result[pos.id] and neotest_result[pos.id].status == "skipped" then
     -- keep the status if it was already decided to be skipped.
-    neotest_result[pos.id] ~= nil
-    and neotest_result[pos.id].status == "skipped"
-  then
     result_status = "skipped"
   elseif context.errors ~= nil and #context.errors > 0 then
     -- mark as failed if a non-gotest error occurred.

--- a/lua/neotest-golang/process.lua
+++ b/lua/neotest-golang/process.lua
@@ -7,12 +7,8 @@ local logger = require("neotest-golang.logging")
 local options = require("neotest-golang.options")
 local lib = require("neotest-golang.lib")
 
--- TODO: remove pos_type when properly supporting all position types.
--- and instead get this from the pos.type field.
-
 --- @class RunspecContext
 --- @field pos_id string Neotest tree position id.
---- @field pos_type neotest.PositionType Neotest tree position type.
 --- @field golist_data table<string, string> Filepath to 'go list' JSON data (lua table). -- TODO: rename to golist_data
 --- @field golist_error? string Error message from 'go list' command.
 --- @field parse_test_results boolean If true, parsing of test output will occur.
@@ -77,16 +73,6 @@ function M.test_results(spec, result, tree)
   --- The Neotest position tree node for this execution.
   --- @type neotest.Position
   local pos = tree:data()
-
-  -- Sanity check
-  -- TODO: refactor so that we use pos.type and pos.id instead of passing them separately on the context
-  if options.get().dev_notifications == true then
-    if pos.id ~= context.pos_id then
-      logger.error(
-        "Neotest position id mismatch: " .. pos.id .. " vs " .. context.pos_id
-      )
-    end
-  end
 
   --- The runner to use for running tests.
   --- @type string

--- a/lua/neotest-golang/process.lua
+++ b/lua/neotest-golang/process.lua
@@ -55,18 +55,15 @@ function M.test_results(spec, result, tree)
   --- @type table<string, neotest.Result>
   local neotest_result = {}
 
-  -- return early if we're not supposed to parse test results
+  -- return early...
   if context.parse_test_results == false then
-    ---@type table<string, neotest.Result>
+    -- if we're not supposed to parse test results.
     neotest_result[context.pos_id] = {
-      ---@type neotest.ResultStatus
       status = result_status,
     }
     return neotest_result
-  end
-
-  -- return early if there was an error with running 'go list'
-  if #context.errors > 0 then
+  elseif #context.errors > 0 then
+    -- if there are errors passed with the context.
     local test_command_output_path = vim.fs.normalize(async.fn.tempname())
     async.fn.writefile(context.errors, test_command_output_path)
 

--- a/lua/neotest-golang/process.lua
+++ b/lua/neotest-golang/process.lua
@@ -116,8 +116,8 @@ function M.test_results(spec, result, tree)
   -- show various warnings
   M.show_warnings(res)
 
-  -- Convert internal test result data into final Neotest result.
-  local test_results = M.to_neotest_result(spec, result, res, gotest_output)
+  -- convert internal test result data into final Neotest result.
+  local test_results = M.to_neotest_result(res)
   for k, v in pairs(test_results) do
     neotest_result[k] = v
   end
@@ -393,12 +393,9 @@ function M.show_warnings(d)
 end
 
 --- Populate final Neotest results based on internal test result data.
---- @param spec neotest.RunSpec
---- @param result neotest.StrategyResult
 --- @param res table<string, TestData>
---- @param gotest_output table
 --- @return table<string, neotest.Result>
-function M.to_neotest_result(spec, result, res, gotest_output)
+function M.to_neotest_result(res)
   --- Neotest results.
   --- @type table<string, neotest.Result>
   local neotest_result = {}

--- a/lua/neotest-golang/process.lua
+++ b/lua/neotest-golang/process.lua
@@ -9,7 +9,7 @@ local lib = require("neotest-golang.lib")
 
 --- @class RunspecContext
 --- @field pos_id string Neotest tree position id.
---- @field golist_data table<string, string> Filepath to 'go list' JSON data (lua table). -- TODO: rename to golist_data
+--- @field golist_data table<string, string> Filepath to 'go list' JSON data (lua table).
 --- @field golist_error? string Error message from 'go list' command.
 --- @field parse_test_results boolean If true, parsing of test output will occur.
 --- @field test_output_json_filepath? string Gotestsum JSON filepath.

--- a/lua/neotest-golang/process.lua
+++ b/lua/neotest-golang/process.lua
@@ -11,7 +11,7 @@ local lib = require("neotest-golang.lib")
 --- @field pos_id string Neotest tree position id.
 --- @field golist_data table<string, string> The 'go list' JSON data (lua table).
 --- @field errors? table<string> Non-gotest errors to show in the final output.
---- @field process_test_results boolean If true, parsing of test output will occur.
+--- @field is_dap_active boolean? If true, parsing of test output will occur.
 --- @field test_output_json_filepath? string Gotestsum JSON filepath.
 
 --- @class TestData
@@ -44,10 +44,10 @@ function M.test_results(spec, result, tree)
   --- @type table<string, neotest.Result>
   local neotest_result = {}
 
-  -- ////// RETURN EARLY //////
+  -- ////// RETURN EARLY FOR DAP DEBUGGING //////
 
-  -- return early if test result processing is not desired.
-  if context.process_test_results == false then
+  if context.is_dap_active then
+    -- return early if test result processing is not desired.
     neotest_result[context.pos_id] = {
       status = "skipped",
     }

--- a/lua/neotest-golang/runspec/dir.lua
+++ b/lua/neotest-golang/runspec/dir.lua
@@ -26,6 +26,11 @@ function M.build(pos)
   local go_mod_folderpath = vim.fn.fnamemodify(go_mod_filepath, ":h")
   local golist_data, golist_error = lib.cmd.golist_data(go_mod_folderpath)
 
+  local errors = {}
+  if golist_error ~= nil then
+    table.insert(errors, golist_error)
+  end
+
   -- find the go package that corresponds to the go_mod_folderpath
   local package_name = "./..."
   for _, golist_item in ipairs(golist_data) do
@@ -45,7 +50,7 @@ function M.build(pos)
   local context = {
     pos_id = pos.id,
     golist_data = golist_data,
-    golist_error = golist_error,
+    errors = errors,
     parse_test_results = true,
     test_output_json_filepath = json_filepath,
   }

--- a/lua/neotest-golang/runspec/dir.lua
+++ b/lua/neotest-golang/runspec/dir.lua
@@ -24,7 +24,7 @@ function M.build(pos)
   end
 
   local go_mod_folderpath = vim.fn.fnamemodify(go_mod_filepath, ":h")
-  local golist_data = lib.cmd.golist_data(go_mod_folderpath)
+  local golist_data, golist_error = lib.cmd.golist_data(go_mod_folderpath)
 
   -- find the go package that corresponds to the go_mod_folderpath
   local package_name = "./..."
@@ -46,6 +46,7 @@ function M.build(pos)
     pos_id = pos.id,
     pos_type = "dir",
     golist_data = golist_data,
+    golist_error = golist_error,
     parse_test_results = true,
     test_output_json_filepath = json_filepath,
   }

--- a/lua/neotest-golang/runspec/dir.lua
+++ b/lua/neotest-golang/runspec/dir.lua
@@ -26,8 +26,11 @@ function M.build(pos)
   local go_mod_folderpath = vim.fn.fnamemodify(go_mod_filepath, ":h")
   local golist_data, golist_error = lib.cmd.golist_data(go_mod_folderpath)
 
-  local errors = {}
+  local errors = nil
   if golist_error ~= nil then
+    if errors == nil then
+      errors = {}
+    end
     table.insert(errors, golist_error)
   end
 
@@ -51,7 +54,7 @@ function M.build(pos)
     pos_id = pos.id,
     golist_data = golist_data,
     errors = errors,
-    parse_test_results = true,
+    process_test_results = true,
     test_output_json_filepath = json_filepath,
   }
 

--- a/lua/neotest-golang/runspec/dir.lua
+++ b/lua/neotest-golang/runspec/dir.lua
@@ -54,7 +54,6 @@ function M.build(pos)
     pos_id = pos.id,
     golist_data = golist_data,
     errors = errors,
-    process_test_results = true,
     test_output_json_filepath = json_filepath,
   }
 

--- a/lua/neotest-golang/runspec/dir.lua
+++ b/lua/neotest-golang/runspec/dir.lua
@@ -44,7 +44,6 @@ function M.build(pos)
   --- @type RunspecContext
   local context = {
     pos_id = pos.id,
-    pos_type = "dir",
     golist_data = golist_data,
     golist_error = golist_error,
     parse_test_results = true,

--- a/lua/neotest-golang/runspec/file.lua
+++ b/lua/neotest-golang/runspec/file.lua
@@ -25,6 +25,11 @@ function M.build(pos, tree)
   local go_mod_folderpath = vim.fn.fnamemodify(go_mod_filepath, ":h")
   local golist_data, golist_error = lib.cmd.golist_data(go_mod_folderpath)
 
+  local errors = {}
+  if golist_error ~= nil then
+    table.insert(errors, golist_error)
+  end
+
   -- find the go package that corresponds to the pos.path
   local package_name = "./..."
   local pos_path_filename = vim.fn.fnamemodify(pos.path, ":t")
@@ -59,7 +64,7 @@ function M.build(pos, tree)
   local context = {
     pos_id = pos.id,
     golist_data = golist_data,
-    golist_error = golist_error,
+    errors = errors,
     parse_test_results = true,
     test_output_json_filepath = json_filepath,
   }

--- a/lua/neotest-golang/runspec/file.lua
+++ b/lua/neotest-golang/runspec/file.lua
@@ -68,7 +68,6 @@ function M.build(pos, tree)
     pos_id = pos.id,
     golist_data = golist_data,
     errors = errors,
-    process_test_results = true,
     test_output_json_filepath = json_filepath,
   }
 
@@ -88,7 +87,6 @@ function M.return_skipped(pos)
   local context = {
     pos_id = pos.id,
     golist_data = {}, -- no golist output
-    process_test_results = false,
   }
 
   --- Runspec designed for files that contain no tests.

--- a/lua/neotest-golang/runspec/file.lua
+++ b/lua/neotest-golang/runspec/file.lua
@@ -25,8 +25,11 @@ function M.build(pos, tree)
   local go_mod_folderpath = vim.fn.fnamemodify(go_mod_filepath, ":h")
   local golist_data, golist_error = lib.cmd.golist_data(go_mod_folderpath)
 
-  local errors = {}
+  local errors = nil
   if golist_error ~= nil then
+    if errors == nil then
+      errors = {}
+    end
     table.insert(errors, golist_error)
   end
 
@@ -65,7 +68,7 @@ function M.build(pos, tree)
     pos_id = pos.id,
     golist_data = golist_data,
     errors = errors,
-    parse_test_results = true,
+    process_test_results = true,
     test_output_json_filepath = json_filepath,
   }
 
@@ -85,7 +88,7 @@ function M.return_skipped(pos)
   local context = {
     pos_id = pos.id,
     golist_data = {}, -- no golist output
-    parse_test_results = false,
+    process_test_results = false,
   }
 
   --- Runspec designed for files that contain no tests.

--- a/lua/neotest-golang/runspec/file.lua
+++ b/lua/neotest-golang/runspec/file.lua
@@ -23,7 +23,7 @@ function M.build(pos, tree)
   end
 
   local go_mod_folderpath = vim.fn.fnamemodify(go_mod_filepath, ":h")
-  local golist_data = lib.cmd.golist_data(go_mod_folderpath)
+  local golist_data, golist_error = lib.cmd.golist_data(go_mod_folderpath)
 
   -- find the go package that corresponds to the pos.path
   local package_name = "./..."
@@ -60,6 +60,7 @@ function M.build(pos, tree)
     pos_id = pos.id,
     pos_type = "file",
     golist_data = golist_data,
+    golist_error = golist_error,
     parse_test_results = true,
     test_output_json_filepath = json_filepath,
   }

--- a/lua/neotest-golang/runspec/file.lua
+++ b/lua/neotest-golang/runspec/file.lua
@@ -58,7 +58,6 @@ function M.build(pos, tree)
   --- @type RunspecContext
   local context = {
     pos_id = pos.id,
-    pos_type = "file",
     golist_data = golist_data,
     golist_error = golist_error,
     parse_test_results = true,
@@ -80,7 +79,6 @@ function M.return_skipped(pos)
   --- @type RunspecContext
   local context = {
     pos_id = pos.id,
-    pos_type = "file",
     golist_data = {}, -- no golist output
     parse_test_results = false,
   }

--- a/lua/neotest-golang/runspec/namespace.lua
+++ b/lua/neotest-golang/runspec/namespace.lua
@@ -8,13 +8,17 @@ local M = {}
 --- @param pos neotest.Position
 --- @return neotest.RunSpec | neotest.RunSpec[] | nil
 function M.build(pos)
-  --- @type string
   local test_folder_absolute_path =
     string.match(pos.path, "(.+)" .. lib.find.os_path_sep)
+
   local golist_data, golist_error =
     lib.cmd.golist_data(test_folder_absolute_path)
 
-  --- @type string
+  local errors = {}
+  if golist_error ~= nil then
+    table.insert(errors, golist_error)
+  end
+
   local test_name = lib.convert.to_gotest_test_name(pos.id)
   test_name = lib.convert.to_gotest_regex_pattern(test_name)
 
@@ -27,7 +31,7 @@ function M.build(pos)
   local context = {
     pos_id = pos.id,
     golist_data = golist_data,
-    golist_error = golist_error,
+    errors = errors,
     parse_test_results = true,
     test_output_json_filepath = json_filepath,
   }

--- a/lua/neotest-golang/runspec/namespace.lua
+++ b/lua/neotest-golang/runspec/namespace.lua
@@ -11,7 +11,8 @@ function M.build(pos)
   --- @type string
   local test_folder_absolute_path =
     string.match(pos.path, "(.+)" .. lib.find.os_path_sep)
-  local golist_data = lib.cmd.golist_data(test_folder_absolute_path)
+  local golist_data, golist_error =
+    lib.cmd.golist_data(test_folder_absolute_path)
 
   --- @type string
   local test_name = lib.convert.to_gotest_test_name(pos.id)
@@ -27,6 +28,7 @@ function M.build(pos)
     pos_id = pos.id,
     pos_type = "namespace",
     golist_data = golist_data,
+    golist_error = golist_error,
     parse_test_results = true,
     test_output_json_filepath = json_filepath,
   }

--- a/lua/neotest-golang/runspec/namespace.lua
+++ b/lua/neotest-golang/runspec/namespace.lua
@@ -26,7 +26,6 @@ function M.build(pos)
   --- @type RunspecContext
   local context = {
     pos_id = pos.id,
-    pos_type = "namespace",
     golist_data = golist_data,
     golist_error = golist_error,
     parse_test_results = true,

--- a/lua/neotest-golang/runspec/namespace.lua
+++ b/lua/neotest-golang/runspec/namespace.lua
@@ -1,5 +1,6 @@
 --- Helpers to build the command and context around running all tests in a namespace.
 
+local logger = require("neotest-golang.logging")
 local lib = require("neotest-golang.lib")
 
 local M = {}
@@ -14,8 +15,11 @@ function M.build(pos)
   local golist_data, golist_error =
     lib.cmd.golist_data(test_folder_absolute_path)
 
-  local errors = {}
+  local errors = nil
   if golist_error ~= nil then
+    if errors == nil then
+      errors = {}
+    end
     table.insert(errors, golist_error)
   end
 
@@ -32,7 +36,7 @@ function M.build(pos)
     pos_id = pos.id,
     golist_data = golist_data,
     errors = errors,
-    parse_test_results = true,
+    process_test_results = true,
     test_output_json_filepath = json_filepath,
   }
 

--- a/lua/neotest-golang/runspec/namespace.lua
+++ b/lua/neotest-golang/runspec/namespace.lua
@@ -36,7 +36,6 @@ function M.build(pos)
     pos_id = pos.id,
     golist_data = golist_data,
     errors = errors,
-    process_test_results = true,
     test_output_json_filepath = json_filepath,
   }
 

--- a/lua/neotest-golang/runspec/test.lua
+++ b/lua/neotest-golang/runspec/test.lua
@@ -59,7 +59,7 @@ function M.build(pos, strategy)
 
   if runspec_strategy ~= nil then
     run_spec.strategy = runspec_strategy
-    run_spec.context.process_test_results = false
+    run_spec.context.is_dap_active = true
   end
 
   logger.debug({ "RunSpec:", run_spec })

--- a/lua/neotest-golang/runspec/test.lua
+++ b/lua/neotest-golang/runspec/test.lua
@@ -11,13 +11,17 @@ local M = {}
 --- @param strategy string
 --- @return neotest.RunSpec | neotest.RunSpec[] | nil
 function M.build(pos, strategy)
-  --- @type string
   local test_folder_absolute_path =
     string.match(pos.path, "(.+)" .. lib.find.os_path_sep)
+
   local golist_data, golist_error =
     lib.cmd.golist_data(test_folder_absolute_path)
 
-  --- @type string
+  local errors = {}
+  if golist_error ~= nil then
+    table.insert(errors, golist_error)
+  end
+
   local test_name = lib.convert.to_gotest_test_name(pos.id)
   local test_name_regex = lib.convert.to_gotest_regex_pattern(test_name)
 
@@ -38,7 +42,7 @@ function M.build(pos, strategy)
   local context = {
     pos_id = pos.id,
     golist_data = golist_data,
-    golist_error = golist_error,
+    errors = errors,
     parse_test_results = true,
     test_output_json_filepath = json_filepath,
   }

--- a/lua/neotest-golang/runspec/test.lua
+++ b/lua/neotest-golang/runspec/test.lua
@@ -17,8 +17,11 @@ function M.build(pos, strategy)
   local golist_data, golist_error =
     lib.cmd.golist_data(test_folder_absolute_path)
 
-  local errors = {}
+  local errors = nil
   if golist_error ~= nil then
+    if errors == nil then
+      errors = {}
+    end
     table.insert(errors, golist_error)
   end
 
@@ -43,7 +46,7 @@ function M.build(pos, strategy)
     pos_id = pos.id,
     golist_data = golist_data,
     errors = errors,
-    parse_test_results = true,
+    process_test_results = true,
     test_output_json_filepath = json_filepath,
   }
 
@@ -56,7 +59,7 @@ function M.build(pos, strategy)
 
   if runspec_strategy ~= nil then
     run_spec.strategy = runspec_strategy
-    run_spec.context.parse_test_results = false
+    run_spec.context.process_test_results = false
   end
 
   logger.debug({ "RunSpec:", run_spec })

--- a/lua/neotest-golang/runspec/test.lua
+++ b/lua/neotest-golang/runspec/test.lua
@@ -37,7 +37,6 @@ function M.build(pos, strategy)
   --- @type RunspecContext
   local context = {
     pos_id = pos.id,
-    pos_type = "test",
     golist_data = golist_data,
     golist_error = golist_error,
     parse_test_results = true,

--- a/lua/neotest-golang/runspec/test.lua
+++ b/lua/neotest-golang/runspec/test.lua
@@ -14,7 +14,8 @@ function M.build(pos, strategy)
   --- @type string
   local test_folder_absolute_path =
     string.match(pos.path, "(.+)" .. lib.find.os_path_sep)
-  local golist_data = lib.cmd.golist_data(test_folder_absolute_path)
+  local golist_data, golist_error =
+    lib.cmd.golist_data(test_folder_absolute_path)
 
   --- @type string
   local test_name = lib.convert.to_gotest_test_name(pos.id)
@@ -38,6 +39,7 @@ function M.build(pos, strategy)
     pos_id = pos.id,
     pos_type = "test",
     golist_data = golist_data,
+    golist_error = golist_error,
     parse_test_results = true,
     test_output_json_filepath = json_filepath,
   }


### PR DESCRIPTION
fixes #169

### Why this change?

* When there's e.g. a compilation error, this is not properly handled. Often the error shown is "Test(s) not associated" which is not very clear.

### What was changed?

- Make `go list` failure show as Neotest test failure.
- Make `go test` failure show as a Neotest test failure. Supports both `go` and `gotestsum` runners.
- Added ability to pass various errors onto the RunSpec context.

### Screenshot

<img width="1576" alt="image" src="https://github.com/user-attachments/assets/3ab8ac82-6269-44db-954e-ad41c87a7c63">

### Try it out

```lua
{
  "fredrikaverpil/neotest-golang",
  branch = "output-on-failure",
},
```

