### PR TITLE
fix: keep all lines until next log entry

### DIFF
--- a/lua/neotest-golang/utils/buffer.lua
+++ b/lua/neotest-golang/utils/buffer.lua
@@ -9,21 +9,31 @@ function M.filter(word)
   -- Get all lines in the buffer
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
 
-  -- Create a new table to store lines containing the word
+  -- Create a new table to store filtered lines
   local new_lines = {}
+
+  -- Flag to track if we're currently in a matching block
+  local in_matching_block = false
 
   -- Iterate through all lines
   for _, line in ipairs(lines) do
-    -- If the line contains "neotest-golang", add it to new_lines
-    if line:match(lib.convert.to_lua_pattern(word)) then
+    -- Check if the line starts with a log level
+    local is_log_start = line:match("^%u+%s+|")
+
+    if is_log_start then
+      -- If it's a new log entry, reset the flag
+      in_matching_block = false
+    end
+
+    -- If the line contains the word or we're in a matching block, add it
+    if line:match(lib.convert.to_lua_pattern(word)) or in_matching_block then
       table.insert(new_lines, line)
+      in_matching_block = true
     end
   end
 
   -- Replace the buffer contents with the new lines
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, new_lines)
-
-  vim.notify("Removed lines not containing '" .. word .. "'")
 end
 
 return M


### PR DESCRIPTION
### Why?

When running `:lua require("neotest-golang.utils.buffer").filter("[neotest-golang]")`, the filter will not keep newlines for the log entry.

### What?

Before:

```
DEBUG | 2024-09-07T17:28:13Z+0200 | ...ode/public/neotest-golang/lua/neotest-golang/logging.lua:47 | [neotest-golang] DAP strategy used: {
DEBUG | 2024-09-07T17:28:13Z+0200 | ...ode/public/neotest-golang/lua/neotest-golang/logging.lua:47 | [neotest-golang] Provided dap_go_opts for DAP:  {
```

After:

```
DEBUG | 2024-09-07T17:31:39Z+0200 | ...ode/public/neotest-golang/lua/neotest-golang/logging.lua:47 | [neotest-golang] DAP strategy used: {
  args = { "-test.run", "^TestTopLevelWithSubTest/SubTest$" },
  buildFlags = { "-tags=integration" },
  mode = "test",
  name = "Neotest-golang",
  program = "${fileDirname}",
  request = "launch",
  type = "go"
}
DEBUG | 2024-09-07T17:31:39Z+0200 | ...ode/public/neotest-golang/lua/neotest-golang/logging.lua:47 | [neotest-golang] Provided dap_go_opts for DAP:  {
  delve = {
    build_flags = { "-tags=integration" },
    cwd = "/Users/fredrik/code/public/neotest-golang/tests/go"
  }
}
```