### PR TITLE
feat: add ability to pass args as function instead of table

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,14 +141,14 @@ consider setting up neotest and its adapters in a
 
 ## ⚙️ Configuration
 
-| Argument                 | Default value                   | Description                                                                                                                                                          |
-| ------------------------ | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `go_test_args`           | `{ "-v", "-race", "-count=1" }` | Arguments to pass into `go test`. See [here](https://github.com/fredrikaverpil/neotest-golang#using-build-tags) for info on using `-tags`.                           |
-| `go_list_args`           | `{}`                            | Arguments to pass into `go list`. See [here](https://github.com/fredrikaverpil/neotest-golang#using-build-tags) for info on using `-tags`.                           |
-| `dap_go_opts`            | `{}`                            | Options to pass into `require("dap-go").setup()`.                                                                                                                    |
-| `testify_enabled`        | `false`                         | Enable support for [testify](https://github.com/stretchr/testify) suites. See [here](https://github.com/fredrikaverpil/neotest-golang#testify-suites) for more info. |
-| `warn_test_name_dupes`   | `true`                          | Warn about duplicate test names within the same Go package.                                                                                                          |
-| `warn_test_not_executed` | `true`                          | Warn if test was not executed.                                                                                                                                       |
+| Argument                 | Default value                   | Description                                                                                                                                                                                                                                        |
+| ------------------------ | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `go_test_args`           | `{ "-v", "-race", "-count=1" }` | Arguments to pass into `go test`. Note: [`-tags` usage](https://github.com/fredrikaverpil/neotest-golang#using-build-tags), [pass args as function](https://github.com/fredrikaverpil/neotest-golang#pass-arguments-as-function-instead-of-table). |
+| `go_list_args`           | `{}`                            | Arguments to pass into `go list`. Note: [`-tags` usage](https://github.com/fredrikaverpil/neotest-golang#using-build-tags), [pass args as function](https://github.com/fredrikaverpil/neotest-golang#pass-arguments-as-function-instead-of-table). |
+| `dap_go_opts`            | `{}`                            | Options to pass into `require("dap-go").setup()`.                                                                                                                                                                                                  |
+| `testify_enabled`        | `false`                         | Enable support for [testify](https://github.com/stretchr/testify) suites. See [here](https://github.com/fredrikaverpil/neotest-golang#testify-suites) for more info.                                                                               |
+| `warn_test_name_dupes`   | `true`                          | Warn about duplicate test names within the same Go package.                                                                                                                                                                                        |
+| `warn_test_not_executed` | `true`                          | Warn if test was not executed.                                                                                                                                                                                                                     |
 
 ### Example configuration: custom `go test` arguments
 
@@ -548,6 +548,35 @@ return {
 > Depending on how you have Neovim setup, you can define this on a per-project
 > basis by placing a `.lazy.lua` with overrides in the project. This requires
 > the [lazy.nvim](https://github.com/folke/lazy.nvim) plugin manager.
+
+### Pass arguments as function instead of table
+
+Some use cases may require you to pass in dynamically generated arguments during
+runtime. To cater for this, you can provide arguments as a function.
+
+```lua
+return {
+  {
+    "nvim-neotest/neotest",
+    config = function()
+      require("neotest").setup({
+        adapters = {
+          require("neotest-golang")({
+            go_test_args = function()
+              -- provide custom logic here..
+              return { "-count=1", "-tags=integration" }
+            end,
+            go_list_args = function()
+              -- provide custom logic here..
+              return { "-tags=integration" }
+            end,
+          }),
+        },
+      })
+    end,
+  },
+}
+```
 
 ## 🙏 PRs are welcome
 

--- a/lua/neotest-golang/lib/cmd.lua
+++ b/lua/neotest-golang/lib/cmd.lua
@@ -37,7 +37,11 @@ end
 
 function M.golist_command()
   local cmd = { "go", "list", "-json" }
-  vim.list_extend(cmd, options.get().go_list_args or {})
+  local go_list_args = options.get().go_list_args
+  if type(go_list_args) == "function" then
+    go_list_args = go_list_args()
+  end
+  vim.list_extend(cmd, go_list_args or {})
   vim.list_extend(cmd, { "./..." })
   return cmd
 end
@@ -81,16 +85,28 @@ end
 
 function M.go_test(go_test_required_args)
   local cmd = { "go", "test", "-json" }
-  cmd = vim.list_extend(vim.deepcopy(cmd), options.get().go_test_args)
+  local args = options.get().go_test_args
+  if type(args) == "function" then
+    args = args()
+  end
+  cmd = vim.list_extend(vim.deepcopy(cmd), args)
   cmd = vim.list_extend(vim.deepcopy(cmd), go_test_required_args)
   return cmd
 end
 
 function M.gotestsum(go_test_required_args, json_filepath)
   local cmd = { "gotestsum", "--jsonfile=" .. json_filepath }
-  cmd = vim.list_extend(vim.deepcopy(cmd), options.get().gotestsum_args)
+  local gotestsum_args = options.get().gotestsum_args
+  if type(gotestsum_args) == "function" then
+    gotestsum_args = gotestsum_args()
+  end
+  local go_test_args = options.get().go_test_args
+  if type(go_test_args) == "function" then
+    go_test_args = go_test_args()
+  end
+  cmd = vim.list_extend(vim.deepcopy(cmd), gotestsum_args)
   cmd = vim.list_extend(vim.deepcopy(cmd), { "--" })
-  cmd = vim.list_extend(vim.deepcopy(cmd), options.get().go_test_args)
+  cmd = vim.list_extend(vim.deepcopy(cmd), go_test_args)
   cmd = vim.list_extend(vim.deepcopy(cmd), go_test_required_args)
   return cmd
 end

--- a/lua/neotest-golang/options.lua
+++ b/lua/neotest-golang/options.lua
@@ -7,8 +7,8 @@ local logger = require("neotest-golang.logging")
 local M = {}
 
 local opts = {
-  go_test_args = { "-v", "-race", "-count=1" },
-  go_list_args = {},
+  go_test_args = { "-v", "-race", "-count=1" }, -- NOTE: can also be a function
+  go_list_args = {}, -- NOTE: can also be a function
   dap_go_opts = {},
   testify_enabled = false,
   warn_test_name_dupes = true,
@@ -16,7 +16,7 @@ local opts = {
 
   -- experimental, for now undocumented, options
   runner = "go", -- or "gotestsum"
-  gotestsum_args = { "--format=standard-verbose" },
+  gotestsum_args = { "--format=standard-verbose" }, -- NOTE: can also be a function
   dev_notifications = false,
 }
 

--- a/tests/unit/options_spec.lua
+++ b/tests/unit/options_spec.lua
@@ -46,4 +46,33 @@ describe("Options are set up", function()
     options.setup(expected_options)
     assert.are_same(expected_options, options.get())
   end)
+
+  it("With args as functions", function()
+    local expected_options = {
+      go_test_args = function()
+        return {
+          "-v",
+          "-race",
+          "-count=1",
+          "-parallel=1",
+        }
+      end,
+      go_list_args = function()
+        return {}
+      end,
+      dap_go_opts = {},
+      testify_enabled = false,
+      warn_test_name_dupes = true,
+      warn_test_not_executed = true,
+
+      -- experimental
+      runner = "go",
+      gotestsum_args = function()
+        return { "--format=standard-verbose" }
+      end,
+      dev_notifications = false,
+    }
+    options.setup(expected_options)
+    assert.are_same(expected_options, options.get())
+  end)
 end)


### PR DESCRIPTION
Fixes #186

### Why?

Some users need to dynamically generate the `go test` command on each test run.

### What?

Supply a function instead of a table as `go test` args:

Please give something like this a try:

```lua
return {
  {
    "nvim-neotest/neotest",
    dependencies = {
      "nvim-neotest/nvim-nio",
      "nvim-lua/plenary.nvim",
      "antoinemadec/FixCursorHold.nvim",
      "nvim-treesitter/nvim-treesitter",
      {
        "fredrikaverpil/neotest-golang", -- Installation
        branch = "args-function", -- Custom branch
      },
    },
    config = function()
      local opts = { -- Specify configuration
        go_test_args = function()
          -- Place your custom logic here for the 'go test' args
          return {
            "-v",
            "-race",
            "-count=1",
            "-coverprofile=" .. vim.fn.getcwd() .. "/coverage.out",
          }
        end,
      }
      require("neotest").setup({
        adapters = {
          require("neotest-golang")(opts), -- Apply configuration
        },
      })
    end,
  },
}
```
