### PR TITLE
feat(dap): pass dap-go opts as function

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,14 +145,14 @@ consider setting up neotest and its adapters in a
 
 ## ⚙️ Configuration
 
-| Argument                 | Default value                   | Description                                                                                                                                                                                                                                        |
-| ------------------------ | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `go_test_args`           | `{ "-v", "-race", "-count=1" }` | Arguments to pass into `go test`. Note: [`-tags` usage](https://github.com/fredrikaverpil/neotest-golang#using-build-tags), [pass args as function](https://github.com/fredrikaverpil/neotest-golang#pass-arguments-as-function-instead-of-table). |
-| `go_list_args`           | `{}`                            | Arguments to pass into `go list`. Note: [`-tags` usage](https://github.com/fredrikaverpil/neotest-golang#using-build-tags), [pass args as function](https://github.com/fredrikaverpil/neotest-golang#pass-arguments-as-function-instead-of-table). |
-| `dap_go_opts`            | `{}`                            | Options to pass into `require("dap-go").setup()`.                                                                                                                                                                                                  |
-| `testify_enabled`        | `false`                         | Enable support for [testify](https://github.com/stretchr/testify) suites. See [here](https://github.com/fredrikaverpil/neotest-golang#testify-suites) for more info.                                                                               |
-| `warn_test_name_dupes`   | `true`                          | Warn about duplicate test names within the same Go package.                                                                                                                                                                                        |
-| `warn_test_not_executed` | `true`                          | Warn if test was not executed.                                                                                                                                                                                                                     |
+| Argument                 | Default value                   | Description                                                                                                                                                                                                                                                        |
+| ------------------------ | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `go_test_args`           | `{ "-v", "-race", "-count=1" }` | Arguments to pass into `go test`. Note: [`-tags` usage](https://github.com/fredrikaverpil/neotest-golang#using-build-tags), [pass args as function](https://github.com/fredrikaverpil/neotest-golang#pass-arguments-as-function-instead-of-table).                 |
+| `go_list_args`           | `{}`                            | Arguments to pass into `go list`. Note: [`-tags` usage](https://github.com/fredrikaverpil/neotest-golang#using-build-tags), [pass args as function](https://github.com/fredrikaverpil/neotest-golang#pass-arguments-as-function-instead-of-table).                 |
+| `dap_go_opts`            | `{}`                            | Options to pass into `require("dap-go").setup()`. Note: [`-tags` usage](https://github.com/fredrikaverpil/neotest-golang#using-build-tags), [pass args as function](https://github.com/fredrikaverpil/neotest-golang#pass-arguments-as-function-instead-of-table). |
+| `testify_enabled`        | `false`                         | Enable support for [testify](https://github.com/stretchr/testify) suites. See [here](https://github.com/fredrikaverpil/neotest-golang#testify-suites) for more info.                                                                                               |
+| `warn_test_name_dupes`   | `true`                          | Warn about duplicate test names within the same Go package.                                                                                                                                                                                                        |
+| `warn_test_not_executed` | `true`                          | Warn if test was not executed.                                                                                                                                                                                                                                     |
 
 ### Example configuration: custom `go test` arguments
 
@@ -574,6 +574,15 @@ return {
               -- provide custom logic here..
               return { "-tags=integration" }
             end,
+            dap_go_opts = function()
+              -- provide custom logic here..
+              return {
+                delve = {
+                  build_flags = { "-tags=integration" },
+                },
+              }
+            end,
+            },
           }),
         },
       })

--- a/lua/neotest-golang/features/dap/init.lua
+++ b/lua/neotest-golang/features/dap/init.lua
@@ -9,6 +9,9 @@ local M = {}
 ---@param cwd string
 function M.setup_debugging(cwd)
   local dap_go_opts = options.get().dap_go_opts or {}
+  if type(dap_go_opts) == "function" then
+    dap_go_opts = dap_go_opts()
+  end
   local dap_go_opts_original = vim.deepcopy(dap_go_opts)
   if dap_go_opts.delve == nil then
     dap_go_opts.delve = {}

--- a/tests/unit/options_spec.lua
+++ b/tests/unit/options_spec.lua
@@ -60,7 +60,9 @@ describe("Options are set up", function()
       go_list_args = function()
         return {}
       end,
-      dap_go_opts = {},
+      dap_go_opts = function()
+        return {}
+      end,
       testify_enabled = false,
       warn_test_name_dupes = true,
       warn_test_not_executed = true,


### PR DESCRIPTION
### Why?

For `go test` and `go list`, args can be provided as functions. But I didn't add this for the dap-go opts, where you might have similar needs (e.g. if you need to compute the build tags in runtime rather than on adapter initialization).

### What?

Add capability to pass in function for dap-go.