### PR TITLE
fix(dap): use test filepath from neotest positions

### DIFF
--- a/lua/neotest-golang/features/dap/init.lua
+++ b/lua/neotest-golang/features/dap/init.lua
@@ -30,17 +30,18 @@ function M.setup_debugging(cwd)
   end
 end
 
+--- @param test_path string
 --- @param test_name_regex string
 --- @return table | nil
-function M.get_dap_config(test_name_regex)
+function M.get_dap_config(test_path, test_name_regex)
   -- :help dap-configuration
   local dap_config = {
     type = "go",
     name = "Neotest-golang",
     request = "launch",
     mode = "test",
-    program = "${fileDirname}",
     args = { "-test.run", test_name_regex },
+    program = test_path,
   }
 
   local dap_go_opts = options.get().dap_go_opts or {}

--- a/lua/neotest-golang/runspec/test.lua
+++ b/lua/neotest-golang/runspec/test.lua
@@ -11,8 +11,8 @@ local M = {}
 --- @param strategy string
 --- @return neotest.RunSpec | neotest.RunSpec[] | nil
 function M.build(pos, strategy)
-  local test_folder_absolute_path =
-    string.match(pos.path, "(.+)" .. lib.find.os_path_sep)
+  local pos_path_foldername = vim.fn.fnamemodify(pos.path, ":h")
+  local test_folder_absolute_path = pos_path_foldername
 
   local golist_data, golist_error =
     lib.cmd.golist_data(test_folder_absolute_path)
@@ -36,7 +36,7 @@ function M.build(pos, strategy)
   local runspec_strategy = nil
   if strategy == "dap" then
     M.assert_dap_prerequisites()
-    runspec_strategy = dap.get_dap_config(test_name_regex)
+    runspec_strategy = dap.get_dap_config(pos_path_foldername, test_name_regex)
     logger.debug("DAP strategy used: " .. vim.inspect(runspec_strategy))
     dap.setup_debugging(test_folder_absolute_path)
   end


### PR DESCRIPTION
# Why is this PR needed

Currently when trying to debug tests via the Neotest Summary panel, the generated `dap_configuration` is not correct.

The variable `fileDirname` is expanded in nvim-dap as `vim.fn.expand("%:p:h")`
See https://github.com/mfussenegger/nvim-dap/blob/7ff6936010b7222fea2caea0f67ed77f1b7c60dd/lua/dap.lua#L338-L340

When the focus is on the summary panel, this returns the current working directory. 

Since we already know the exact path to the testfile by neotests positions, there's no need to rely on the information about the current window returned by `vim.fn.expand` function present in the dap client.