### PR TITLE
feat: using DAP without nvim-dap-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Reliable Neotest adapter for running Go tests in Neovim.
 - DAP support with [leoluz/nvim-dap-go](https://github.com/leoluz/nvim-dap-go)
   integration for debugging of tests using
   [delve](https://github.com/go-delve/delve).
+- DAP support for your own DAP configuration.
 - Monorepo support (detect, run and debug tests in sub-projects).
 - Inline diagnostics.
 - Custom `go test` argument support.

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Reliable Neotest adapter for running Go tests in Neovim.
 - Supports all [Neotest usage](https://github.com/nvim-neotest/neotest#usage).
 - Supports table tests and nested test functions (based on treesitter AST
   parsing).
-- DAP support with [leoluz/nvim-dap-go](https://github.com/leoluz/nvim-dap-go)
-  integration for debugging of tests using
+- DAP support. Either with
+  [leoluz/nvim-dap-go](https://github.com/leoluz/nvim-dap-go) integration or
+  custom configuration for debugging of tests using
   [delve](https://github.com/go-delve/delve).
-- DAP support for your own DAP configuration.
 - Monorepo support (detect, run and debug tests in sub-projects).
 - Inline diagnostics.
 - Custom `go test` argument support.
@@ -222,15 +222,17 @@ See `go help test`, `go help testflag`, `go help build` for possible arguments.
 
 To debug tests, make sure you depend on
 [mfussenegger/nvim-dap](https://github.com/mfussenegger/nvim-dap) and
-[rcarriga/nvim-dap-ui](https://github.com/rcarriga/nvim-dap-ui). At now you have
-2 possible configurations:
+[rcarriga/nvim-dap-ui](https://github.com/rcarriga/nvim-dap-ui). Then you have
+two options:
 
-- Using [leoluz/nvim-dap-go](https://github.com/leoluz/nvim-dap-go)
-- Using own DAP configuration
+- Adapter-provided DAP configuration, leveraging
+  [leoluz/nvim-dap-go](https://github.com/leoluz/nvim-dap-go) (recommended).
+- Use your own custom DAP configuration (no additional dependency needed).
 
-#### Using nvim-dap-go
+Example configurations:
 
-For example, make the following changes to your lua setup:
+<details>
+<summary>Adapter-provided configuration</summary>
 
 ```diff
 return {
@@ -268,9 +270,10 @@ return {
 }
 ```
 
-#### Using manual DAP configuration
+</details>
 
-You can use this configuration
+<details>
+<summary>Custom DAP configuration</summary>
 
 ```diff
 return {
@@ -309,6 +312,8 @@ return {
   },
 }
 ```
+
+</details>
 
 Finally, set a keymap, like:
 

--- a/README.md
+++ b/README.md
@@ -221,10 +221,16 @@ See `go help test`, `go help testflag`, `go help build` for possible arguments.
 ### Example configuration: debugging
 
 To debug tests, make sure you depend on
-[mfussenegger/nvim-dap](https://github.com/mfussenegger/nvim-dap),
-[rcarriga/nvim-dap-ui](https://github.com/rcarriga/nvim-dap-ui) and
-[leoluz/nvim-dap-go](https://github.com/leoluz/nvim-dap-go). For example, make
-the following changes to your lua setup:
+[mfussenegger/nvim-dap](https://github.com/mfussenegger/nvim-dap) and
+[rcarriga/nvim-dap-ui](https://github.com/rcarriga/nvim-dap-ui). At now you have
+2 possible configurations:
+
+- Using [leoluz/nvim-dap-go](https://github.com/leoluz/nvim-dap-go)
+- Using own DAP configuration
+
+#### Using nvim-dap-go
+
+For example, make the following changes to your lua setup:
 
 ```diff
 return {
@@ -255,6 +261,48 @@ return {
       require("neotest").setup({
         adapters = {
           require("neotest-golang"), -- Registration
+        },
+      })
+    end,
+  },
+}
+```
+
+#### Using manual DAP configuration
+
+You can use this configuration
+
+```diff
+return {
++  {
++    "rcarriga/nvim-dap-ui",
++    dependencies = {
++      "nvim-neotest/nvim-nio",
++      "mfussenegger/nvim-dap",
++    },
++  },
++
+  {
+    "nvim-neotest/neotest",
+    dependencies = {
+      "nvim-neotest/nvim-nio",
+      "nvim-lua/plenary.nvim",
+      "antoinemadec/FixCursorHold.nvim",
+      "nvim-treesitter/nvim-treesitter",
+      "fredrikaverpil/neotest-golang", -- Installation
+    },
+    config = function()
+      require("neotest").setup({
+        adapters = {
++         require("neotest-golang") { -- Registration
++           dap_mode = "manual",
++           dap_manual_config = {
++               name = "Debug go tests",
++               type = "go", -- Preconfigured DAP adapter name
++               request = "launch",
++               mode = "test",
++           }
++         },
         },
       })
     end,

--- a/lua/neotest-golang/features/dap/dap_go.lua
+++ b/lua/neotest-golang/features/dap/dap_go.lua
@@ -1,0 +1,68 @@
+--- DAP (dap-go) setup related functions.
+
+local options = require("neotest-golang.options")
+local logger = require("neotest-golang.logging")
+
+local M = {}
+
+---This will prepare and setup nvim-dap-go for debugging.
+---@param cwd string
+function M.setup_debugging(cwd)
+  local dap_go_opts = options.get().dap_go_opts or {}
+  if type(dap_go_opts) == "function" then
+    dap_go_opts = dap_go_opts()
+  end
+  local dap_go_opts_original = vim.deepcopy(dap_go_opts)
+  if dap_go_opts.delve == nil then
+    dap_go_opts.delve = {}
+  end
+  dap_go_opts.delve.cwd = cwd
+  logger.debug({ "Provided dap_go_opts for DAP: ", dap_go_opts })
+  require("dap-go").setup(dap_go_opts)
+
+  -- reset nvim-dap-go (and cwd) after debugging with nvim-dap
+  require("dap").listeners.after.event_terminated["neotest-golang-debug"] = function()
+    logger.debug({
+      "Resetting provided dap_go_opts for DAP: ",
+      dap_go_opts_original,
+    })
+    require("dap-go").setup(dap_go_opts_original)
+  end
+end
+
+--- @param test_path string
+--- @param test_name_regex string?
+--- @return table | nil
+function M.get_dap_config(test_path, test_name_regex)
+  -- :help dap-configuration
+  local dap_config = {
+    type = "go",
+    name = "Neotest-golang",
+    request = "launch",
+    mode = "test",
+    program = test_path,
+  }
+
+  if test_name_regex ~= nil then
+    dap_config.args = { "-test.run", test_name_regex }
+  end
+
+  local dap_go_opts = options.get().dap_go_opts or {}
+  if dap_go_opts.delve ~= nil and dap_go_opts.delve.build_flags ~= nil then
+    dap_config.buildFlags = dap_go_opts.delve.build_flags
+  end
+
+  return dap_config
+end
+
+function M.assert_dap_prerequisites()
+  local dap_go_found = pcall(require, "dap-go")
+  if not dap_go_found then
+    local msg = "You must have leoluz/nvim-dap-go installed to use DAP strategy. "
+      .. "See the neotest-golang README for more information."
+    logger.error(msg)
+    error(msg)
+  end
+end
+
+return M

--- a/lua/neotest-golang/features/dap/dap_manual.lua
+++ b/lua/neotest-golang/features/dap/dap_manual.lua
@@ -35,7 +35,6 @@ function M.get_dap_config(test_path, test_name_regex)
 end
 
 ---Dummy function is needed to be corresponding to dap-go setup (just like trait implementation)
-function M.assert_dap_prerequisites()
-end
+function M.assert_dap_prerequisites() end
 
 return M

--- a/lua/neotest-golang/features/dap/dap_manual.lua
+++ b/lua/neotest-golang/features/dap/dap_manual.lua
@@ -1,20 +1,17 @@
 --- DAP (manual dap configuration) setup related functions.
 
 local options = require("neotest-golang.options")
-local logger = require("neotest-golang.logging")
-
-local dap = require("dap")
 
 local M = {}
 
 ---@param cwd string
 function M.setup_debugging(cwd)
-  local dap_manual_configuration = options.get().dap_manual_configuration or {}
-  if type(dap_manual_configuration) == "function" then
-    dap_manual_configuration = dap_manual_configuration()
+  local dap_manual_config = options.get().dap_manual_config or {}
+  if type(dap_manual_config) == "function" then
+    dap_manual_config = dap_manual_config()
   end
 
-  dap_manual_configuration.cwd = cwd
+  dap_manual_config.cwd = cwd
 end
 
 ---This will setup a dap configuration to run tests
@@ -22,24 +19,23 @@ end
 ---@param test_name_regex string?
 ---@return table | nil
 function M.get_dap_config(test_path, test_name_regex)
-  local dap_manual_configuration = options.get().dap_manual_configuration or {}
-  if type(dap_manual_configuration) == "function" then
-    dap_manual_configuration = dap_manual_configuration()
+  local dap_manual_config = options.get().dap_manual_config or {}
+  if type(dap_manual_config) == "function" then
+    dap_manual_config = dap_manual_config()
   end
 
-  dap_manual_configuration.program = test_path
+  dap_manual_config.program = test_path
 
   if test_name_regex ~= nil then
-    dap_manual_configuration.args = dap_manual_configuration.args or {}
-    table.insert(dap_manual_configuration.args, "-test.run")
-    table.insert(dap_manual_configuration.args, test_name_regex)
+    dap_manual_config.args = dap_manual_config.args or {}
+    table.insert(dap_manual_config.args, "-test.run")
+    table.insert(dap_manual_config.args, test_name_regex)
   end
-  return dap_manual_configuration
+  return dap_manual_config
 end
 
 ---Dummy function is needed to be corresponding to dap-go setup (just like trait implementation)
 function M.assert_dap_prerequisites()
-  logger.debug("Nothing to check. Manual DAP configuration in use")
 end
 
 return M

--- a/lua/neotest-golang/features/dap/dap_manual.lua
+++ b/lua/neotest-golang/features/dap/dap_manual.lua
@@ -1,0 +1,45 @@
+--- DAP (manual dap configuration) setup related functions.
+
+local options = require("neotest-golang.options")
+local logger = require("neotest-golang.logging")
+
+local dap = require("dap")
+
+local M = {}
+
+---@param cwd string
+function M.setup_debugging(cwd)
+  local dap_manual_configuration = options.get().dap_manual_configuration or {}
+  if type(dap_manual_configuration) == "function" then
+    dap_manual_configuration = dap_manual_configuration()
+  end
+
+  dap_manual_configuration.cwd = cwd
+end
+
+---This will setup a dap configuration to run tests
+---@param test_path string
+---@param test_name_regex string?
+---@return table | nil
+function M.get_dap_config(test_path, test_name_regex)
+  local dap_manual_configuration = options.get().dap_manual_configuration or {}
+  if type(dap_manual_configuration) == "function" then
+    dap_manual_configuration = dap_manual_configuration()
+  end
+
+  dap_manual_configuration.program = test_path
+
+  if test_name_regex ~= nil then
+    dap_manual_configuration.args = dap_manual_configuration.args or {}
+    table.insert(dap_manual_configuration.args, "-test.run")
+    table.insert(dap_manual_configuration.args, test_name_regex)
+  end
+  return dap_manual_configuration
+end
+
+---Dummy function is needed to be corresponding to dap-go setup (just like trait implementation)
+function M.assert_dap_prerequisites()
+  logger.debug("Nothing to check. Manual DAP configuration in use")
+end
+
+return M

--- a/lua/neotest-golang/features/dap/init.lua
+++ b/lua/neotest-golang/features/dap/init.lua
@@ -18,9 +18,9 @@ local function get_dap_implementation()
     dap_impl = require("neotest-golang.features.dap.dap_manual")
   else
     local msg = "Got dap-mode: `"
-    .. selected_dap_mode
-    .. "` that cannot be used. "
-    .. "See the neotest-golang README for more information."
+      .. selected_dap_mode
+      .. "` that cannot be used. "
+      .. "See the neotest-golang README for more information."
     logger.error(msg)
     error(msg)
   end

--- a/lua/neotest-golang/features/dap/init.lua
+++ b/lua/neotest-golang/features/dap/init.lua
@@ -1,32 +1,25 @@
 --- DAP setup related functions.
 
 local options = require("neotest-golang.options")
-local logger = require("neotest-golang.logging")
+local dap_manual = require("neotest-golang.features.dap.dap_manual")
+local dap_go = require("neotest-golang.features.dap.dap_go")
 
 local M = {}
 
----This will prepare and setup nvim-dap-go for debugging.
+local function is_dap_manual_enabled()
+  local dap_manual_enabled = options.get().dap_manual_enabled
+  if type(dap_manual_enabled) == "function" then
+    dap_manual_enabled = dap_manual_enabled()
+  end
+  return dap_manual_enabled
+end
+
 ---@param cwd string
 function M.setup_debugging(cwd)
-  local dap_go_opts = options.get().dap_go_opts or {}
-  if type(dap_go_opts) == "function" then
-    dap_go_opts = dap_go_opts()
-  end
-  local dap_go_opts_original = vim.deepcopy(dap_go_opts)
-  if dap_go_opts.delve == nil then
-    dap_go_opts.delve = {}
-  end
-  dap_go_opts.delve.cwd = cwd
-  logger.debug({ "Provided dap_go_opts for DAP: ", dap_go_opts })
-  require("dap-go").setup(dap_go_opts)
-
-  -- reset nvim-dap-go (and cwd) after debugging with nvim-dap
-  require("dap").listeners.after.event_terminated["neotest-golang-debug"] = function()
-    logger.debug({
-      "Resetting provided dap_go_opts for DAP: ",
-      dap_go_opts_original,
-    })
-    require("dap-go").setup(dap_go_opts_original)
+  if is_dap_manual_enabled() then
+    dap_manual.setup_debugging(cwd)
+  else
+    dap_go.setup_debugging(cwd)
   end
 end
 
@@ -34,34 +27,18 @@ end
 --- @param test_name_regex string?
 --- @return table | nil
 function M.get_dap_config(test_path, test_name_regex)
-  -- :help dap-configuration
-  local dap_config = {
-    type = "go",
-    name = "Neotest-golang",
-    request = "launch",
-    mode = "test",
-    program = test_path,
-  }
-
-  if test_name_regex ~= nil then
-    dap_config.args = { "-test.run", test_name_regex }
+  if is_dap_manual_enabled() then
+    return dap_manual.get_dap_config(test_path, test_name_regex)
+  else
+    return dap_go.get_dap_config(test_path, test_name_regex)
   end
-
-  local dap_go_opts = options.get().dap_go_opts or {}
-  if dap_go_opts.delve ~= nil and dap_go_opts.delve.build_flags ~= nil then
-    dap_config.buildFlags = dap_go_opts.delve.build_flags
-  end
-
-  return dap_config
 end
 
 function M.assert_dap_prerequisites()
-  local dap_go_found = pcall(require, "dap-go")
-  if not dap_go_found then
-    local msg = "You must have leoluz/nvim-dap-go installed to use DAP strategy. "
-      .. "See the neotest-golang README for more information."
-    logger.error(msg)
-    error(msg)
+  if is_dap_manual_enabled() then
+    dap_manual.assert_dap_prerequisites()
+  else
+    dap_go.assert_dap_prerequisites()
   end
 end
 

--- a/lua/neotest-golang/features/dap/init.lua
+++ b/lua/neotest-golang/features/dap/init.lua
@@ -1,24 +1,28 @@
 --- DAP setup related functions.
 
 local options = require("neotest-golang.options")
+local logger = require("neotest-golang.logging")
 
 local M = {}
 
-local function is_dap_manual_enabled()
-  local dap_manual_enabled = options.get().dap_manual_enabled
-  if type(dap_manual_enabled) == "function" then
-    dap_manual_enabled = dap_manual_enabled()
-  end
-  return dap_manual_enabled
-end
-
 local function get_dap_implementation()
   local dap_impl
-  if is_dap_manual_enabled() then
+  local selected_dap_mode = options.get().dap_mode
+  if type(selected_dap_mode) == "function" then
+    selected_dap_mode = selected_dap_mode()
+  end
+
+  if selected_dap_mode == "dap-go" then
+    dap_impl = require("neotest-golang.features.dap.dap_go")
+  elseif selected_dap_mode == "manual" then
     dap_impl = require("neotest-golang.features.dap.dap_manual")
   else
-    dap_impl = require("neotest-golang.features.dap.dap_go")
+    local msg = "Got dap-mode: `" .. selected_dap_mode .. "` that cannot be used. "
+    .. "See the neotest-golang README for more information."
+    logger.error(msg)
+    error(msg)
   end
+
   return dap_impl
 end
 

--- a/lua/neotest-golang/features/dap/init.lua
+++ b/lua/neotest-golang/features/dap/init.lua
@@ -1,8 +1,6 @@
 --- DAP setup related functions.
 
 local options = require("neotest-golang.options")
-local dap_manual = require("neotest-golang.features.dap.dap_manual")
-local dap_go = require("neotest-golang.features.dap.dap_go")
 
 local M = {}
 
@@ -14,32 +12,33 @@ local function is_dap_manual_enabled()
   return dap_manual_enabled
 end
 
+local function get_dap_implementation()
+  local dap_impl
+  if is_dap_manual_enabled() then
+    dap_impl = require("neotest-golang.features.dap.dap_manual")
+  else
+    dap_impl = require("neotest-golang.features.dap.dap_go")
+  end
+  return dap_impl
+end
+
 ---@param cwd string
 function M.setup_debugging(cwd)
-  if is_dap_manual_enabled() then
-    dap_manual.setup_debugging(cwd)
-  else
-    dap_go.setup_debugging(cwd)
-  end
+  local dap_impl = get_dap_implementation()
+  dap_impl.setup_debugging(cwd)
 end
 
 --- @param test_path string
 --- @param test_name_regex string?
 --- @return table | nil
 function M.get_dap_config(test_path, test_name_regex)
-  if is_dap_manual_enabled() then
-    return dap_manual.get_dap_config(test_path, test_name_regex)
-  else
-    return dap_go.get_dap_config(test_path, test_name_regex)
-  end
+  local dap_impl = get_dap_implementation()
+  return dap_impl.get_dap_config(test_path, test_name_regex)
 end
 
 function M.assert_dap_prerequisites()
-  if is_dap_manual_enabled() then
-    dap_manual.assert_dap_prerequisites()
-  else
-    dap_go.assert_dap_prerequisites()
-  end
+  local dap_impl = get_dap_implementation()
+  dap_impl.assert_dap_prerequisites()
 end
 
 return M

--- a/lua/neotest-golang/features/dap/init.lua
+++ b/lua/neotest-golang/features/dap/init.lua
@@ -17,7 +17,9 @@ local function get_dap_implementation()
   elseif selected_dap_mode == "manual" then
     dap_impl = require("neotest-golang.features.dap.dap_manual")
   else
-    local msg = "Got dap-mode: `" .. selected_dap_mode .. "` that cannot be used. "
+    local msg = "Got dap-mode: `"
+    .. selected_dap_mode
+    .. "` that cannot be used. "
     .. "See the neotest-golang README for more information."
     logger.error(msg)
     error(msg)

--- a/lua/neotest-golang/options.lua
+++ b/lua/neotest-golang/options.lua
@@ -12,8 +12,8 @@ local opts = {
   gotestsum_args = { "--format=standard-verbose" }, -- NOTE: can also be a function
   go_list_args = {}, -- NOTE: can also be a function
   dap_go_opts = {}, -- NOTE: can also be a function
-  dap_manual_enabled = false, -- NOTE: can alse be a function
-  dap_manual_configuration = {}, -- NOTE: can also be a function
+  dap_mode = "dap-go", -- NOTE: or "manual" ; can also be a function
+  dap_manual_config = {}, -- NOTE: can also be a function
   testify_enabled = false,
   colorize_test_output = true,
   warn_test_name_dupes = true,

--- a/lua/neotest-golang/options.lua
+++ b/lua/neotest-golang/options.lua
@@ -12,6 +12,8 @@ local opts = {
   gotestsum_args = { "--format=standard-verbose" }, -- NOTE: can also be a function
   go_list_args = {}, -- NOTE: can also be a function
   dap_go_opts = {}, -- NOTE: can also be a function
+  dap_manual_enabled = false, -- NOTE: can alse be a function
+  dap_manual_configuration = {}, -- NOTE: can also be a function
   testify_enabled = false,
   colorize_test_output = true,
   warn_test_name_dupes = true,

--- a/tests/unit/options_spec.lua
+++ b/tests/unit/options_spec.lua
@@ -13,6 +13,8 @@ describe("Options are set up", function()
       go_list_args = {},
       gotestsum_args = { "--format=standard-verbose" },
       dap_go_opts = {},
+      dap_manual_enabled = false,
+      dap_manual_configuration = {},
       testify_enabled = false,
       colorize_test_output = true,
       warn_test_name_dupes = true,
@@ -37,6 +39,8 @@ describe("Options are set up", function()
       go_list_args = {},
       gotestsum_args = { "--format=standard-verbose" },
       dap_go_opts = {},
+      dap_manual_enabled = false,
+      dap_manual_configuration = {},
       testify_enabled = false,
       colorize_test_output = false,
       warn_test_name_dupes = true,
@@ -63,6 +67,12 @@ describe("Options are set up", function()
         return {}
       end,
       dap_go_opts = function()
+        return {}
+      end,
+      dap_manual_enabled = function()
+        return false
+      end,
+      dap_manual_configuration = function()
         return {}
       end,
       testify_enabled = false,

--- a/tests/unit/options_spec.lua
+++ b/tests/unit/options_spec.lua
@@ -13,8 +13,8 @@ describe("Options are set up", function()
       go_list_args = {},
       gotestsum_args = { "--format=standard-verbose" },
       dap_go_opts = {},
-      dap_manual_enabled = false,
-      dap_manual_configuration = {},
+      dap_mode = "dap-go",
+      dap_manual_config = {},
       testify_enabled = false,
       colorize_test_output = true,
       warn_test_name_dupes = true,
@@ -39,8 +39,8 @@ describe("Options are set up", function()
       go_list_args = {},
       gotestsum_args = { "--format=standard-verbose" },
       dap_go_opts = {},
-      dap_manual_enabled = false,
-      dap_manual_configuration = {},
+      dap_mode = "dap-go",
+      dap_manual_config = {},
       testify_enabled = false,
       colorize_test_output = false,
       warn_test_name_dupes = true,
@@ -69,10 +69,10 @@ describe("Options are set up", function()
       dap_go_opts = function()
         return {}
       end,
-      dap_manual_enabled = function()
-        return false
+      dap_mode = function()
+        return "dap-go"
       end,
-      dap_manual_configuration = function()
+      dap_manual_config = function()
         return {}
       end,
       testify_enabled = false,


### PR DESCRIPTION
Hello! I have a nvim config that contains a many of DAP configurations for some languages, also for golang. I don't want to install additional plugin special for debugging go apps or tests (this breaks a consistency of my config). I setup own DAP configuration for this and wanna use it to debug tests with your plugin.