### PR TITLE
feat: show build error in test output

### DIFF
--- a/lua/neotest-golang/lib/cmd.lua
+++ b/lua/neotest-golang/lib/cmd.lua
@@ -25,7 +25,7 @@ function M.golist_data(cwd)
     if result.stdout ~= nil and result.stderr ~= "" then
       err = err .. " " .. result.stderr
     end
-    logger.debug({ "Go list error: ", err })
+    logger.warn({ "Go list error: ", err })
   end
 
   local output = result.stdout or ""

--- a/tests/go/subpackage/subpackage_test.go
+++ b/tests/go/subpackage/subpackage_test.go
@@ -1,0 +1,9 @@
+package subpackage
+
+import "testing"
+
+func TestSubpackage(t *testing.T) {
+	if (1 + 2) != 3 {
+		t.Fail()
+	}
+}

--- a/tests/go/testify/lookup_spec.lua
+++ b/tests/go/testify/lookup_spec.lua
@@ -15,6 +15,10 @@ describe("Lookup", function()
         package = "main",
         replacements = {},
       },
+      [folderpath .. "/subpackage/subpackage_test.go"] = {
+        package = "subpackage",
+        replacements = {},
+      },
       [folderpath .. "/testify/othersuite_test.go"] = {
         package = "testify",
         replacements = {


### PR DESCRIPTION
fixes #218

🚧 
- [x] More accurately catch build errors.
- [x] Propagate failure status to all tests in affected go package.
- [x] Verify that `go list` errors fit into this new error handling.
