### PR TITLE
fix: recursively run tests for dir

### DIFF
--- a/tests/go/lookup_spec.lua
+++ b/tests/go/lookup_spec.lua
@@ -15,8 +15,12 @@ describe("Lookup", function()
         package = "main",
         replacements = {},
       },
-      [folderpath .. "/subpackage/subpackage_test.go"] = {
-        package = "subpackage",
+      [folderpath .. "/subpackage/subpackage2/subpackage2_test.go"] = {
+        package = "subpackage2",
+        replacements = {},
+      },
+      [folderpath .. "/subpackage/subpackage2/subpackage3/subpackage3_test.go"] = {
+        package = "subpackage3",
         replacements = {},
       },
       [folderpath .. "/testify/othersuite_test.go"] = {

--- a/tests/go/subpackage/subpackage2/subpackage2_test.go
+++ b/tests/go/subpackage/subpackage2/subpackage2_test.go
@@ -1,0 +1,9 @@
+package subpackage2
+
+import "testing"
+
+func TestSubpackage2(t *testing.T) {
+	if (1 + 2) != 3 {
+		t.Fail()
+	}
+}

--- a/tests/go/subpackage/subpackage2/subpackage3/subpackage3_test.go
+++ b/tests/go/subpackage/subpackage2/subpackage3/subpackage3_test.go
@@ -1,0 +1,9 @@
+package subpackage3
+
+import "testing"
+
+func TestSubpackage3(t *testing.T) {
+	if (1 + 2) != 3 {
+		t.Fail()
+	}
+}

--- a/tests/go/subpackage/subpackage_test.go
+++ b/tests/go/subpackage/subpackage_test.go
@@ -1,9 +1,0 @@
-package subpackage
-
-import "testing"
-
-func TestSubpackage(t *testing.T) {
-	if (1 + 2) != 3 {
-		t.Fail()
-	}
-}


### PR DESCRIPTION
## Why this change?

The current implementation did _not_ take into account:

* Recursively run tests for given package (in sub-packages).
* If no exact correlation was found between folder path and package import path, a search for sub-packages is conducted. The result can be used for inferring a proper package import path.

Huge thanks to @damoye for uncovering this rather large bug! ❤️ 

### What was done?

* Introduce two search strategies for correlating the selected folderpath with a package import path.
* Append `/...` at the end of the package import path.

___

fixes: #228