### PR TITLE
feat: add benchmark support

### DIFF
--- a/lua/neotest-golang/lib/cmd.lua
+++ b/lua/neotest-golang/lib/cmd.lua
@@ -52,8 +52,19 @@ function M.test_command_in_package(package_or_path)
   return cmd, json_filepath
 end
 
-function M.test_command_in_package_with_regexp(package_or_path, regexp)
-  local go_test_required_args = { package_or_path, "-run", regexp }
+function M.test_command_in_package_with_regexp(
+  package_or_path, -- this is a filepath when running individual tests, otherwise it's the package's import path
+  regexp,
+  is_benchmark
+)
+  local go_test_required_args = { package_or_path }
+
+  if is_benchmark then
+    vim.list_extend(go_test_required_args, { "-run", "^$", "-bench", regexp })
+  else
+    vim.list_extend(go_test_required_args, { "-run", regexp })
+  end
+
   local cmd, json_filepath = M.test_command(go_test_required_args)
   return cmd, json_filepath
 end

--- a/lua/neotest-golang/query.lua
+++ b/lua/neotest-golang/query.lua
@@ -10,7 +10,7 @@ local M = {}
 M.test_function = [[
     ; query for test function
     ((function_declaration
-      name: (identifier) @test.name) (#match? @test.name "^(Test|Example)") (#not-match? @test.name "^TestMain$"))
+      name: (identifier) @test.name) (#match? @test.name "^(Test|Example|Benchmark)") (#not-match? @test.name "^TestMain$"))
       @test.definition
 
     ; query for subtest, like t.Run()

--- a/lua/neotest-golang/runspec/file.lua
+++ b/lua/neotest-golang/runspec/file.lua
@@ -68,7 +68,7 @@ function M.build(pos, tree, strategy)
   local regexp = M.get_regexp(pos.path)
   if regexp ~= nil then
     test_cmd, json_filepath =
-      lib.cmd.test_command_in_package_with_regexp(package_name, regexp)
+      lib.cmd.test_command_in_package_with_regexp(package_name, regexp, false)
   else
     -- fallback: run all tests in the package
     test_cmd, json_filepath = lib.cmd.test_command_in_package(package_name)

--- a/lua/neotest-golang/runspec/namespace.lua
+++ b/lua/neotest-golang/runspec/namespace.lua
@@ -28,7 +28,8 @@ function M.build(pos)
 
   local test_cmd, json_filepath = lib.cmd.test_command_in_package_with_regexp(
     test_folder_absolute_path,
-    test_name
+    test_name,
+    false
   )
 
   --- @type RunspecContext

--- a/lua/neotest-golang/runspec/test.lua
+++ b/lua/neotest-golang/runspec/test.lua
@@ -28,9 +28,15 @@ function M.build(pos, strategy)
   local test_name = lib.convert.to_gotest_test_name(pos.id)
   local test_name_regex = lib.convert.to_gotest_regex_pattern(test_name)
 
+  local is_benchmark = false
+  if string.match(pos.name, "^Benchmark") then
+    is_benchmark = true
+  end
+
   local test_cmd, json_filepath = lib.cmd.test_command_in_package_with_regexp(
     test_folder_absolute_path,
-    test_name_regex
+    test_name_regex,
+    is_benchmark
   )
 
   local runspec_strategy = nil

--- a/tests/go/internal/benchmark/benchmark_test.go
+++ b/tests/go/internal/benchmark/benchmark_test.go
@@ -1,0 +1,27 @@
+package benchmark
+
+import "testing"
+
+func add(a, b int) int {
+	return a + b
+}
+
+func multiply(a, b int) int {
+	return a * b
+}
+
+func BenchmarkOperations(b *testing.B) {
+	// TODO: make it possible to run b.Run sub-benchmarks?
+
+	b.Run("Addition", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			add(5, 7)
+		}
+	})
+
+	b.Run("Multiplication", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			multiply(5, 7)
+		}
+	})
+}

--- a/tests/go/internal/operand/operand_test.go
+++ b/tests/go/internal/operand/operand_test.go
@@ -1,6 +1,8 @@
 package operand
 
-import "testing"
+import (
+	"testing"
+)
 
 type dummy struct{}
 
@@ -16,16 +18,6 @@ func Test_Run(t *testing.T) {
 
 	router := dummy{}
 	router.Run("don't find me", func(t *testing.T) {
-	})
-}
-
-func Benchmark_Run(b *testing.B) {
-	// NOTE: support for benchmarks could potentially be added.
-	b.Run("benchmark case", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			// Add benchmark logic here
-			dummy{}.Run("test", func(t *testing.T) {})
-		}
 	})
 }
 

--- a/tests/go/lookup_spec.lua
+++ b/tests/go/lookup_spec.lua
@@ -11,6 +11,10 @@ describe("Lookup", function()
     local folderpath = vim.uv.cwd() .. "/tests/go"
     local filepaths = lib.find.go_test_filepaths(vim.uv.cwd())
     local expected_lookup = {
+      [folderpath .. "/internal/benchmark/benchmark_test.go"] = {
+        package = "benchmark",
+        replacements = {},
+      },
       [folderpath .. "/internal/operand/operand_test.go"] = {
         package = "operand",
         replacements = {},

--- a/tests/unit/golist_spec.lua
+++ b/tests/unit/golist_spec.lua
@@ -91,7 +91,7 @@ describe("go list output from internal", function()
     local tests_filepath = vim.uv.cwd() .. "/tests/go"
     local internal_filepath = vim.uv.cwd() .. "/tests/go/internal"
     local output = lib.cmd.golist_data(internal_filepath)
-    local first_entry = output[2]
+    local first_entry = output[3]
     local expected = {
 
       Deps = {


### PR DESCRIPTION
### Why this change?

It was asked for in
https://github.com/fredrikaverpil/neotest-golang/discussions/227

### What was changed?

Added the ability to run a single benchmark.

If you execute all tests in a dir or file, any benchmarks will be skipped.

### Todo

- [ ] Consider if this should really be merged in... (is it useful, do I want to
      maintain this?)
- [ ] Refactor, the code is way too entangled with "regular" tests logic now.
- [ ] Add tests.
