### PR TITLE
fix: false positives on structs

### DIFF
--- a/lua/neotest-golang/query.lua
+++ b/lua/neotest-golang/query.lua
@@ -59,74 +59,100 @@ M.table_tests = [[
     ;; query for list table tests (wrapped in loop)
     (for_statement
       (range_clause
-          left: (expression_list 
+          left: (expression_list
             (identifier)
-            (identifier) @test.case ) 
-          right: (composite_literal 
-            type: (slice_type 
-              element: (struct_type 
-                (field_declaration_list 
-                  (field_declaration 
-                    name: (field_identifier) 
+            (identifier) @test.case )
+          right: (composite_literal
+            type: (slice_type
+              element: (struct_type
+                (field_declaration_list
+                  (field_declaration
+                    name: (field_identifier)
                     type: (type_identifier)))))
             body: (literal_value
-              (literal_element 
-                (literal_value 
-                  (keyed_element 
-                    (literal_element 
-                      (identifier))  @test.field.name 
-                    (literal_element 
+              (literal_element
+                (literal_value
+                  (keyed_element
+                    (literal_element
+                      (identifier))  @test.field.name
+                    (literal_element
                       (interpreted_string_literal) @test.name ))
                   ) @test.definition)
               )))
-        body: (block 
-          (expression_statement 
-            (call_expression 
-              function: (selector_expression 
-                operand: (identifier) 
-                field: (field_identifier)) 
-              arguments: (argument_list 
-                (selector_expression 
-                  operand: (identifier) 
+        body: (block
+          (expression_statement
+            (call_expression
+              function: (selector_expression
+                operand: (identifier)
+                field: (field_identifier))
+              arguments: (argument_list
+                (selector_expression
+                  operand: (identifier)
                   field: (field_identifier) @test.field.name1) (#eq? @test.field.name @test.field.name1))))))
 
     ;; Query for table tests with inline structs (not keyed)
-    (function_declaration
-      name: (identifier)
-      parameters: (parameter_list
-        (parameter_declaration
-          name: (identifier)
-          type: (pointer_type
-            (qualified_type
-              package: (package_identifier)
-              name: (type_identifier))))))
-      body: (block
+    (block
+        (short_var_declaration
+          left: (expression_list (identifier) @test.cases)
+          right: (expression_list
+            (composite_literal
+                body: (literal_value
+                  (literal_element
+                    (literal_value
+                      (literal_element (interpreted_string_literal) @test.name)
+                      (literal_element)) @test.definition)))))
         (for_statement
           (range_clause
-            left: (expression_list
-              (identifier)
-              (identifier))
-            right: (composite_literal
+              left: (expression_list
+                ((identifier) @test.key.name)
+                ((identifier) @test.case))
+              right: (identifier) @test.cases1
+                (#eq? @test.cases @test.cases1))
+          body: (block
+            (expression_statement
+              (call_expression
+                  function: (selector_expression
+                      field: (field_identifier) @test.method)
+                        (#match? @test.method "^Run$")
+                      arguments: (argument_list
+                        (selector_expression
+                            operand: (identifier) @test.case1
+                              (#eq? @test.case @test.case1))))))))
+
+    ;; Query for table tests with inline structs (not keyed, wrapped in loop)
+    (for_statement
+      (range_clause
+          left: (expression_list
+            (identifier)
+            (identifier) @test.case)
+          right: (composite_literal
               type: (slice_type
-                element: (struct_type
-                  (field_declaration_list
-                    (field_declaration
-                      name: (field_identifier) ; unkeyed field for test name
-                      type: (type_identifier) @field.type (#eq? @field.type "string") )))))))) 
+                  element: (struct_type
+                    (field_declaration_list
+                      (field_declaration
+                          name: (field_identifier) @test.field.name
+                          type: (type_identifier) @field.type (#eq? @field.type "string")))))
+
               body: (literal_value
                 (literal_element
                   (literal_value
                     (literal_element
                       (interpreted_string_literal) @test.name)
-                    (literal_element)) @test.definition))
-          body: (block
-            (expression_statement
-              (call_expression
-                function: (selector_expression
-                  operand: (identifier)
-                  field: (field_identifier) @test.method (#match? @test.method "^Run$")))))
+                    (literal_element)) @test.definition))))
+      body: (block
+        (expression_statement
+          (call_expression
+              function: (selector_expression
+                  field: (field_identifier) @test.method)
+                    (#match? @test.method "^Run$")
+                  arguments: (argument_list
+                      (selector_expression
+                          operand: (identifier) @test.case1
+                            (#eq? @test.case @test.case1)
+                          field: (field_identifier) @test.field.name1
+                            (#eq? @test.field.name @test.field.name1)))))))
 
-    ;; query for map table tests 
+    ;; query for map table tests
       (block
           (short_var_declaration
             left: (expression_list

--- a/tests/go/positions_spec.lua
+++ b/tests/go/positions_spec.lua
@@ -308,6 +308,14 @@ describe("Discovery of test positions", function()
           },
         },
       },
+      {
+        {
+          id = test_filepath .. "::TestStructNotTableTest",
+          name = "TestStructNotTableTest",
+          path = test_filepath,
+          type = "test",
+        },
+      },
     }
 
     -- Act

--- a/tests/go/positions_test.go
+++ b/tests/go/positions_test.go
@@ -216,3 +216,21 @@ func TestTableTestMap(t *testing.T) {
 		})
 	}
 }
+
+// Struct which is not a table test.
+func TestStructNotTableTest(t *testing.T) {
+	type item struct {
+		id   string
+		name string
+	}
+	items := []item{
+		{"1", "one"},
+		{"2", "two"},
+	}
+
+	for _, i := range items {
+		if i.id == "" {
+			t.Fail()
+		}
+	}
+}


### PR DESCRIPTION
Ignore structs which are not being used as test tables.

For example, here "1" and "2" are reported as test examples:
```go
func TestStruct(t *testing.T) {
	type item struct {
		id   string
		name string
	}
	items := []item{
		{"1", "one"},
		{"2", "two"},
	}

	for _, i := range items {
		if i.id == "" {
			t.Fail()
		}
	}
}
```

<details>
<summary>Before</summary>
<img width="457" alt="Screenshot 2024-12-19 at 12 39 56" src="https://github.com/user-attachments/assets/3677b07c-7fa5-4e2c-9313-a73ee38d5436" />
</details>

<details>
<summary>After</summary>
<img width="457" alt="Screenshot 2024-12-19 at 12 42 39" src="https://github.com/user-attachments/assets/986d5e8a-8322-4026-b741-00e25faeb029" />
</details>