### PR TITLE
fix: only detect t.Run

### DIFF
--- a/lua/neotest-golang/query.lua
+++ b/lua/neotest-golang/query.lua
@@ -16,6 +16,7 @@ M.test_function = [[
     ; query for subtest, like t.Run()
     (call_expression
       function: (selector_expression
+        operand: (identifier) @test.operand (#match? @test.operand "^[t]$")
         field: (field_identifier) @test.method) (#match? @test.method "^Run$")
       arguments: (argument_list . (interpreted_string_literal) @test.name))
       @test.definition
@@ -47,6 +48,7 @@ M.table_tests = [[
              (expression_statement
               (call_expression
                 function: (selector_expression
+                  operand: (identifier) @test.operand (#match? @test.operand "^[t]$")
                   field: (field_identifier) @test.method)
                   (#match? @test.method "^Run$")
                 arguments: (argument_list
@@ -112,6 +114,7 @@ M.table_tests = [[
             (expression_statement
               (call_expression
                   function: (selector_expression
+                      operand: (identifier) @test.operand (#match? @test.operand "^[t]$")
                       field: (field_identifier) @test.method)
                         (#match? @test.method "^Run$")
                       arguments: (argument_list
@@ -143,6 +146,7 @@ M.table_tests = [[
         (expression_statement
           (call_expression
               function: (selector_expression
+                  operand: (identifier) @test.operand (#match? @test.operand "^[t]$")
                   field: (field_identifier) @test.method)
                     (#match? @test.method "^Run$")
                   arguments: (argument_list
@@ -176,6 +180,7 @@ M.table_tests = [[
                (expression_statement
                 (call_expression
                   function: (selector_expression
+                    operand: (identifier) @test.operand (#match? @test.operand "^[t]$")
                     field: (field_identifier) @test.method)
                     (#match? @test.method "^Run$")
                     arguments: (argument_list

--- a/tests/go/internal/operand/operand_test.go
+++ b/tests/go/internal/operand/operand_test.go
@@ -1,0 +1,45 @@
+package operand
+
+import "testing"
+
+type dummy struct{}
+
+func (dummy) Run(string, func(t *testing.T)) {}
+
+func Test_Run(t *testing.T) {
+	t.Run("find me", func(t *testing.T) {
+	})
+
+	x := dummy{}
+	x.Run("don't find me", func(t *testing.T) {
+	})
+
+	router := dummy{}
+	router.Run("don't find me", func(t *testing.T) {
+	})
+}
+
+func Benchmark_Run(b *testing.B) {
+	// NOTE: support for benchmarks could potentially be added.
+	b.Run("benchmark case", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			// Add benchmark logic here
+			dummy{}.Run("test", func(t *testing.T) {})
+		}
+	})
+}
+
+func FuzzRun(f *testing.F) {
+	// NOTE: support for fuzz tests could potentially be added.
+
+	// Add seed corpus
+	f.Add("test input")
+
+	// Actual fuzz test
+	f.Fuzz(func(t2 *testing.T, input string) {
+		t := dummy{}
+		t.Run(input, func(t *testing.T) {
+			// Add fuzzing logic here
+		})
+	})
+}

--- a/tests/go/lookup_spec.lua
+++ b/tests/go/lookup_spec.lua
@@ -11,6 +11,10 @@ describe("Lookup", function()
     local folderpath = vim.uv.cwd() .. "/tests/go"
     local filepaths = lib.find.go_test_filepaths(vim.uv.cwd())
     local expected_lookup = {
+      [folderpath .. "/internal/operand/operand_test.go"] = {
+        package = "operand",
+        replacements = {},
+      },
       [folderpath .. "/internal/positions/positions_test.go"] = {
         package = "positions",
         replacements = {},

--- a/tests/unit/golist_spec.lua
+++ b/tests/unit/golist_spec.lua
@@ -91,7 +91,7 @@ describe("go list output from internal", function()
     local tests_filepath = vim.uv.cwd() .. "/tests/go"
     local internal_filepath = vim.uv.cwd() .. "/tests/go/internal"
     local output = lib.cmd.golist_data(internal_filepath)
-    local first_entry = output[1]
+    local first_entry = output[2]
     local expected = {
 
       Deps = {


### PR DESCRIPTION
### Why?

Turns out that `x.Run`, `router.Run`, `gin.Engine.Run()` was detected as tests.

### What?

Tighten up the tree-sitter query so to only look for `t.Run`.

