### PR TITLE
Run command in another process to avoid freezing neovim

### DIFF
--- a/lua/neotest-golang/lib/cmd.lua
+++ b/lua/neotest-golang/lib/cmd.lua
@@ -14,21 +14,22 @@ function M.golist_data(cwd)
   local cmd = M.golist_command()
   local go_list_command_concat = table.concat(cmd, " ")
   logger.info("Running Go list: " .. go_list_command_concat .. " in " .. cwd)
-  local result = vim.system(cmd, { cwd = cwd, text = true }):wait()
+  local result = async.process.run({cmd = table.remove(cmd, 1), args = cmd , cwd = cwd})
+  local output = result.stdout.read()
+  local error = result.stderr.read()
 
+  local command_return_code = result.result()
   local err = nil
-  if result.code == 1 then
+  if command_return_code == 1 then
     err = "go list:"
-    if result.stdout ~= nil and result.stdout ~= "" then
-      err = err .. " " .. result.stdout
+    if output  ~= nil and output ~= "" then
+      err = err .. " " .. output
     end
-    if result.stdout ~= nil and result.stderr ~= "" then
-      err = err .. " " .. result.stderr
+    if output ~= nil and error ~= "" then
+      err = err .. " " .. error
     end
     logger.warn({ "Go list error: ", err })
   end
-
-  local output = result.stdout or ""
 
   local golist_output = json.decode_from_string(output)
   logger.debug({ "JSON-decoded 'go list' output: ", golist_output })

--- a/lua/neotest-golang/lib/json.lua
+++ b/lua/neotest-golang/lib/json.lua
@@ -12,7 +12,7 @@ function M.decode_from_table(tbl, construct_invalid)
   local jsonlines = {}
   for _, line in ipairs(tbl) do
     if string.match(line, "^%s*{") then -- must start with the `{` character
-      local status, json_data = pcall(vim.fn.json_decode, line)
+      local status, json_data = pcall(vim.json.decode, line)
       if status then
         table.insert(jsonlines, json_data)
       else


### PR DESCRIPTION
Firstly, thanks for the plugin!

I'm working in a massive monorepo and Neovim freezes for around 2 seconds when I try to run one test file. I did a little of digging and found out that `go list` was producing around 270k lines of output and taking around 2 seconds to run. I was able to test here and verify that it was the reason for most of my freezing time. 

Changing from `vim.system` to `async.process.run` fixes most of the problem. But I just had to change `vim.fn.json_decode` to `vim.json.decode` because the string now was not utf8 anymore. 

I still have a small freeze, even with this solution, my investigation is saying that the processing of this long string is the cause, but I didn't find a good solution for it yet. But now the experience is way better.