### PR TITLE
perf: lower 'go list' JSON payload size

### DIFF
--- a/lua/neotest-golang/lib/cmd.lua
+++ b/lua/neotest-golang/lib/cmd.lua
@@ -44,13 +44,13 @@ function M.golist_command()
     "go",
     "list",
     "-f",
-    [[{ 
-      "Dir": "{{.Dir}}",
-      "ImportPath": "{{.ImportPath}}",
-      "Name": "{{.Name}}",
-      "TestGoFiles": [{{range $i, $f := .TestGoFiles}}{{if $i}},{{end}}"{{$f}}"{{end}}],
-      "XTestGoFiles": [{{range $i, $f := .XTestGoFiles}}{{if $i}},{{end}}"{{$f}}"{{end}}],
-      "Module": { "GoMod": "{{.Module.GoMod}}" }
+    [[{
+    "Dir": "{{.Dir}}",
+    "ImportPath": "{{.ImportPath}}",
+    "Name": "{{.Name}}",
+    "TestGoFiles": [{{range $i, $f := .TestGoFiles}}{{if ne $i 0}},{{end}}"{{$f}}"{{end}}],
+    "XTestGoFiles": [{{range $i, $f := .XTestGoFiles}}{{if ne $i 0}},{{end}}"{{$f}}"{{end}}],
+    "Module": { "GoMod": "{{.Module.GoMod}}" }
     }]],
   }
 

--- a/lua/neotest-golang/lib/cmd.lua
+++ b/lua/neotest-golang/lib/cmd.lua
@@ -36,7 +36,24 @@ function M.golist_data(cwd)
 end
 
 function M.golist_command()
-  local cmd = { "go", "list", "-json" }
+  -- NOTE: original command can contain a lot of data:
+  -- local cmd = { "go", "list", "-json" }
+
+  -- NOTE: optimized command only outputs fields needed:
+  local cmd = {
+    "go",
+    "list",
+    "-f",
+    [[{ 
+      "Dir": "{{.Dir}}",
+      "ImportPath": "{{.ImportPath}}",
+      "Name": "{{.Name}}",
+      "TestGoFiles": [{{range $i, $f := .TestGoFiles}}{{if $i}},{{end}}"{{$f}}"{{end}}],
+      "XTestGoFiles": [{{range $i, $f := .XTestGoFiles}}{{if $i}},{{end}}"{{$f}}"{{end}}],
+      "Module": { "GoMod": "{{.Module.GoMod}}" }
+    }]],
+  }
+
   local go_list_args = options.get().go_list_args
   if type(go_list_args) == "function" then
     go_list_args = go_list_args()

--- a/tests/go/internal/notest/notest.go
+++ b/tests/go/internal/notest/notest.go
@@ -1,0 +1,1 @@
+package notest

--- a/tests/go/internal/two/one_test.go
+++ b/tests/go/internal/two/one_test.go
@@ -1,0 +1,5 @@
+package two
+
+import "testing"
+
+func TestOne(t *testing.T) {}

--- a/tests/go/internal/two/two_test.go
+++ b/tests/go/internal/two/two_test.go
@@ -1,0 +1,5 @@
+package two
+
+import "testing"
+
+func TestTwo(t *testing.T) {}

--- a/tests/go/lookup_spec.lua
+++ b/tests/go/lookup_spec.lua
@@ -40,16 +40,24 @@ describe("Lookup", function()
           ExampleTestSuite2 = "TestExampleTestSuite2",
         },
       },
+      [folderpath .. "/internal/testname/testname_test.go"] = {
+        package = "testname",
+        replacements = {},
+      },
+      [folderpath .. "/internal/two/one_test.go"] = {
+        package = "two",
+        replacements = {},
+      },
+      [folderpath .. "/internal/two/two_test.go"] = {
+        package = "two",
+        replacements = {},
+      },
       [folderpath .. "/internal/x/xtest_blackbox_test.go"] = {
         package = "x_test",
         replacements = {},
       },
       [folderpath .. "/internal/x/xtest_whitebox_test.go"] = {
         package = "x",
-        replacements = {},
-      },
-      [folderpath .. "/internal/testname/testname_test.go"] = {
-        package = "testname",
         replacements = {},
       },
     }

--- a/tests/unit/golist_spec.lua
+++ b/tests/unit/golist_spec.lua
@@ -69,17 +69,34 @@ describe("go list output from root", function()
       Name = "main",
       Root = tests_filepath,
       Stale = true,
+      TestGoFiles = {}, -- NOTE: added here because of custom `go list -f` command
+      XTestGoFiles = {}, -- NOTE: added here because of custom `go list -f` command
     }
 
     -- ignored keys, as they might differ between OS/CI/platforms/too often
-    expected.Module.GoVersion = nil
-    first_entry.Module.GoVersion = nil
+    -- and we are also not interested in them.
     expected.Deps = nil
     first_entry.Deps = nil
-    expected.StaleReason = nil
-    first_entry.StaleReason = nil
-    expected.Target = nil
-    first_entry.Target = nil
+    expected.GoFiles = nil
+    first_entry.GoFiles = nil
+    expected.Imports = nil
+    first_entry.Imports = nil
+    expected.Match = nil
+    first_entry.Match = nil
+    expected.Module.Dir = nil
+    first_entry.Module.Dir = nil
+    expected.Module.GoVersion = nil
+    first_entry.Module.GoVersion = nil
+    expected.Module.Main = nil
+    first_entry.Module.Main = nil
+    expected.Module.Path = nil
+    first_entry.Module.Path = nil
+    expected.Root = nil
+    first_entry.Root = nil
+    expected.Stale = nil
+    first_entry.Stale = nil
+    expected.TestImports = nil
+    first_entry.TestImports = nil
 
     assert.are_same(vim.inspect(expected), vim.inspect(first_entry))
     assert.are_same(expected, first_entry)
@@ -155,18 +172,32 @@ describe("go list output from internal", function()
       Root = tests_filepath,
       Stale = true,
       TestGoFiles = { "positions_test.go" },
+      XTestGoFiles = {}, -- NOTE: added here because of custom `go list -f` command
       TestImports = { "os", "testing" },
     }
 
     -- ignored keys, as they might differ between OS/CI/platforms/too often
-    expected.Module.GoVersion = nil
-    first_entry.Module.GoVersion = nil
+    -- and we are also not interested in them.
     expected.Deps = nil
     first_entry.Deps = nil
-    expected.StaleReason = nil
-    first_entry.StaleReason = nil
-    expected.Target = nil
-    first_entry.Target = nil
+    expected.GoFiles = nil
+    first_entry.GoFiles = nil
+    expected.Match = nil
+    first_entry.Match = nil
+    expected.Module.Dir = nil
+    first_entry.Module.Dir = nil
+    expected.Module.GoVersion = nil
+    first_entry.Module.GoVersion = nil
+    expected.Module.Main = nil
+    first_entry.Module.Main = nil
+    expected.Module.Path = nil
+    first_entry.Module.Path = nil
+    expected.Root = nil
+    first_entry.Root = nil
+    expected.Stale = nil
+    first_entry.Stale = nil
+    expected.TestImports = nil
+    first_entry.TestImports = nil
 
     assert.are_same(vim.inspect(expected), vim.inspect(first_entry))
     assert.are_same(expected, first_entry)
@@ -180,7 +211,6 @@ describe("go list output from internal/positions", function()
     local output = lib.cmd.golist_data(positions_filepath)
     local first_entry = output[1]
     local expected = {
-
       Deps = {
         "cmp",
         "errors",
@@ -242,18 +272,32 @@ describe("go list output from internal/positions", function()
       Root = tests_filepath,
       Stale = true,
       TestGoFiles = { "positions_test.go" },
+      XTestGoFiles = {}, -- NOTE: added here because of custom `go list -f` command
       TestImports = { "os", "testing" },
     }
 
     -- ignored keys, as they might differ between OS/CI/platforms/too often
-    expected.Module.GoVersion = nil
-    first_entry.Module.GoVersion = nil
+    -- and we are also not interested in them.
     expected.Deps = nil
     first_entry.Deps = nil
-    expected.StaleReason = nil
-    first_entry.StaleReason = nil
-    expected.Target = nil
-    first_entry.Target = nil
+    expected.GoFiles = nil
+    first_entry.GoFiles = nil
+    expected.Match = nil
+    first_entry.Match = nil
+    expected.Module.Dir = nil
+    first_entry.Module.Dir = nil
+    expected.Module.GoVersion = nil
+    first_entry.Module.GoVersion = nil
+    expected.Module.Main = nil
+    first_entry.Module.Main = nil
+    expected.Module.Path = nil
+    first_entry.Module.Path = nil
+    expected.Root = nil
+    first_entry.Root = nil
+    expected.Stale = nil
+    first_entry.Stale = nil
+    expected.TestImports = nil
+    first_entry.TestImports = nil
 
     assert.are_same(vim.inspect(expected), vim.inspect(first_entry))
     assert.are_same(expected, first_entry)

--- a/tests/unit/golist_spec.lua
+++ b/tests/unit/golist_spec.lua
@@ -8,95 +8,15 @@ describe("go list output from root", function()
     local output = lib.cmd.golist_data(tests_filepath)
     local first_entry = output[1]
     local expected = {
-
-      Deps = {
-        "cmp",
-        "errors",
-        "fmt",
-        "internal/abi",
-        "internal/bytealg",
-        "internal/chacha8rand",
-        "internal/coverage/rtcov",
-        "internal/cpu",
-        "internal/fmtsort",
-        "internal/goarch",
-        "internal/godebugs",
-        "internal/goexperiment",
-        "internal/goos",
-        "internal/itoa",
-        "internal/oserror",
-        "internal/poll",
-        "internal/race",
-        "internal/reflectlite",
-        "internal/safefilepath",
-        "internal/syscall/execenv",
-        "internal/syscall/unix",
-        "internal/testlog",
-        "internal/unsafeheader",
-        "io",
-        "io/fs",
-        "math",
-        "math/bits",
-        "os",
-        "path",
-        "reflect",
-        "runtime",
-        "runtime/internal/atomic",
-        "runtime/internal/math",
-        "runtime/internal/sys",
-        "slices",
-        "sort",
-        "strconv",
-        "sync",
-        "sync/atomic",
-        "syscall",
-        "time",
-        "unicode",
-        "unicode/utf8",
-        "unsafe",
-      },
       Dir = tests_filepath .. "/cmd/main",
-      GoFiles = { "main.go" },
       ImportPath = "github.com/fredrikaverpil/neotest-golang/cmd/main",
-      Imports = { "fmt" },
-      Match = { "./..." },
       Module = {
-        Dir = tests_filepath,
         GoMod = tests_filepath .. "/go.mod",
-        Main = true,
-        Path = "github.com/fredrikaverpil/neotest-golang",
       },
       Name = "main",
-      Root = tests_filepath,
-      Stale = true,
       TestGoFiles = {}, -- NOTE: added here because of custom `go list -f` command
       XTestGoFiles = {}, -- NOTE: added here because of custom `go list -f` command
     }
-
-    -- ignored keys, as they might differ between OS/CI/platforms/too often
-    -- and we are also not interested in them.
-    expected.Deps = nil
-    first_entry.Deps = nil
-    expected.GoFiles = nil
-    first_entry.GoFiles = nil
-    expected.Imports = nil
-    first_entry.Imports = nil
-    expected.Match = nil
-    first_entry.Match = nil
-    expected.Module.Dir = nil
-    first_entry.Module.Dir = nil
-    expected.Module.GoVersion = nil
-    first_entry.Module.GoVersion = nil
-    expected.Module.Main = nil
-    first_entry.Module.Main = nil
-    expected.Module.Path = nil
-    first_entry.Module.Path = nil
-    expected.Root = nil
-    first_entry.Root = nil
-    expected.Stale = nil
-    first_entry.Stale = nil
-    expected.TestImports = nil
-    first_entry.TestImports = nil
 
     assert.are_same(vim.inspect(expected), vim.inspect(first_entry))
     assert.are_same(expected, first_entry)
@@ -108,96 +28,17 @@ describe("go list output from internal", function()
     local tests_filepath = vim.uv.cwd() .. "/tests/go"
     local internal_filepath = vim.uv.cwd() .. "/tests/go/internal"
     local output = lib.cmd.golist_data(internal_filepath)
-    local first_entry = output[2]
+    local first_entry = output[3]
     local expected = {
-
-      Deps = {
-        "cmp",
-        "errors",
-        "fmt",
-        "internal/abi",
-        "internal/bytealg",
-        "internal/chacha8rand",
-        "internal/coverage/rtcov",
-        "internal/cpu",
-        "internal/fmtsort",
-        "internal/goarch",
-        "internal/godebugs",
-        "internal/goexperiment",
-        "internal/goos",
-        "internal/itoa",
-        "internal/oserror",
-        "internal/poll",
-        "internal/race",
-        "internal/reflectlite",
-        "internal/safefilepath",
-        "internal/syscall/execenv",
-        "internal/syscall/unix",
-        "internal/testlog",
-        "internal/unsafeheader",
-        "io",
-        "io/fs",
-        "math",
-        "math/bits",
-        "os",
-        "path",
-        "reflect",
-        "runtime",
-        "runtime/internal/atomic",
-        "runtime/internal/math",
-        "runtime/internal/sys",
-        "slices",
-        "sort",
-        "strconv",
-        "sync",
-        "sync/atomic",
-        "syscall",
-        "time",
-        "unicode",
-        "unicode/utf8",
-        "unsafe",
-      },
       Dir = internal_filepath .. "/positions",
-      GoFiles = { "add.go" },
       ImportPath = "github.com/fredrikaverpil/neotest-golang/internal/positions",
-      Match = { "./..." },
       Module = {
-        Dir = tests_filepath,
         GoMod = tests_filepath .. "/go.mod",
-        GoVersion = "1.23.1",
-        Main = true,
-        Path = "github.com/fredrikaverpil/neotest-golang",
       },
       Name = "positions",
-      Root = tests_filepath,
-      Stale = true,
       TestGoFiles = { "positions_test.go" },
       XTestGoFiles = {}, -- NOTE: added here because of custom `go list -f` command
-      TestImports = { "os", "testing" },
     }
-
-    -- ignored keys, as they might differ between OS/CI/platforms/too often
-    -- and we are also not interested in them.
-    expected.Deps = nil
-    first_entry.Deps = nil
-    expected.GoFiles = nil
-    first_entry.GoFiles = nil
-    expected.Match = nil
-    first_entry.Match = nil
-    expected.Module.Dir = nil
-    first_entry.Module.Dir = nil
-    expected.Module.GoVersion = nil
-    first_entry.Module.GoVersion = nil
-    expected.Module.Main = nil
-    first_entry.Module.Main = nil
-    expected.Module.Path = nil
-    first_entry.Module.Path = nil
-    expected.Root = nil
-    first_entry.Root = nil
-    expected.Stale = nil
-    first_entry.Stale = nil
-    expected.TestImports = nil
-    first_entry.TestImports = nil
 
     assert.are_same(vim.inspect(expected), vim.inspect(first_entry))
     assert.are_same(expected, first_entry)
@@ -211,93 +52,145 @@ describe("go list output from internal/positions", function()
     local output = lib.cmd.golist_data(positions_filepath)
     local first_entry = output[1]
     local expected = {
-      Deps = {
-        "cmp",
-        "errors",
-        "fmt",
-        "internal/abi",
-        "internal/bytealg",
-        "internal/chacha8rand",
-        "internal/coverage/rtcov",
-        "internal/cpu",
-        "internal/fmtsort",
-        "internal/goarch",
-        "internal/godebugs",
-        "internal/goexperiment",
-        "internal/goos",
-        "internal/itoa",
-        "internal/oserror",
-        "internal/poll",
-        "internal/race",
-        "internal/reflectlite",
-        "internal/safefilepath",
-        "internal/syscall/execenv",
-        "internal/syscall/unix",
-        "internal/testlog",
-        "internal/unsafeheader",
-        "io",
-        "io/fs",
-        "math",
-        "math/bits",
-        "os",
-        "path",
-        "reflect",
-        "runtime",
-        "runtime/internal/atomic",
-        "runtime/internal/math",
-        "runtime/internal/sys",
-        "slices",
-        "sort",
-        "strconv",
-        "sync",
-        "sync/atomic",
-        "syscall",
-        "time",
-        "unicode",
-        "unicode/utf8",
-        "unsafe",
-      },
       Dir = positions_filepath,
-      GoFiles = { "add.go" },
       ImportPath = "github.com/fredrikaverpil/neotest-golang/internal/positions",
-      Match = { "./..." },
       Module = {
-        Dir = tests_filepath,
         GoMod = tests_filepath .. "/go.mod",
-        GoVersion = "1.23.1",
-        Main = true,
-        Path = "github.com/fredrikaverpil/neotest-golang",
       },
       Name = "positions",
-      Root = tests_filepath,
-      Stale = true,
       TestGoFiles = { "positions_test.go" },
       XTestGoFiles = {}, -- NOTE: added here because of custom `go list -f` command
-      TestImports = { "os", "testing" },
     }
 
-    -- ignored keys, as they might differ between OS/CI/platforms/too often
-    -- and we are also not interested in them.
-    expected.Deps = nil
-    first_entry.Deps = nil
-    expected.GoFiles = nil
-    first_entry.GoFiles = nil
-    expected.Match = nil
-    first_entry.Match = nil
-    expected.Module.Dir = nil
-    first_entry.Module.Dir = nil
-    expected.Module.GoVersion = nil
-    first_entry.Module.GoVersion = nil
-    expected.Module.Main = nil
-    first_entry.Module.Main = nil
-    expected.Module.Path = nil
-    first_entry.Module.Path = nil
-    expected.Root = nil
-    first_entry.Root = nil
-    expected.Stale = nil
-    first_entry.Stale = nil
-    expected.TestImports = nil
-    first_entry.TestImports = nil
+    assert.are_same(vim.inspect(expected), vim.inspect(first_entry))
+    assert.are_same(expected, first_entry)
+  end)
+end)
+
+describe("go list output from internal/subpackage", function()
+  it("contains expected keys/values", function()
+    local tests_filepath = vim.uv.cwd() .. "/tests/go"
+    local filepath = vim.uv.cwd() .. "/tests/go/internal/subpackage"
+    local output = lib.cmd.golist_data(filepath)
+    local first_entry = output
+    local expected = {
+      {
+        Dir = filepath .. "/subpackage2",
+        ImportPath = "github.com/fredrikaverpil/neotest-golang/internal/subpackage/subpackage2",
+        Module = {
+          GoMod = tests_filepath .. "/go.mod",
+        },
+        Name = "subpackage2",
+        TestGoFiles = { "subpackage2_test.go" },
+        XTestGoFiles = {}, -- NOTE: added here because of custom `go list -f` command
+      },
+      {
+        Dir = filepath .. "/subpackage2/subpackage3",
+        ImportPath = "github.com/fredrikaverpil/neotest-golang/internal/subpackage/subpackage2/subpackage3",
+        Module = {
+          GoMod = tests_filepath .. "/go.mod",
+        },
+        Name = "subpackage3",
+        TestGoFiles = { "subpackage3_test.go" },
+        XTestGoFiles = {}, -- NOTE: added here because of custom `go list -f` command
+      },
+    }
+
+    assert.are_same(vim.inspect(expected), vim.inspect(first_entry))
+    assert.are_same(expected, first_entry)
+  end)
+end)
+
+describe("go list output from internal/x", function()
+  it("contains expected keys/values", function()
+    local tests_filepath = vim.uv.cwd() .. "/tests/go"
+    local filepath = vim.uv.cwd() .. "/tests/go/internal/x"
+    local output = lib.cmd.golist_data(filepath)
+    local first_entry = output
+    local expected = {
+      {
+        Dir = filepath,
+        ImportPath = "github.com/fredrikaverpil/neotest-golang/internal/x",
+        Module = {
+          GoMod = tests_filepath .. "/go.mod",
+        },
+        Name = "x",
+        TestGoFiles = { "xtest_whitebox_test.go" },
+        XTestGoFiles = { "xtest_blackbox_test.go" }, -- NOTE: added here because of custom `go list -f` command
+      },
+    }
+
+    assert.are_same(vim.inspect(expected), vim.inspect(first_entry))
+    assert.are_same(expected, first_entry)
+  end)
+end)
+
+describe("go list output from internal/x", function()
+  it("contains TestGoFiles and XTestGoFiles", function()
+    local tests_filepath = vim.uv.cwd() .. "/tests/go"
+    local filepath = vim.uv.cwd() .. "/tests/go/internal/x"
+    local output = lib.cmd.golist_data(filepath)
+    local first_entry = output
+    local expected = {
+      {
+        Dir = filepath,
+        ImportPath = "github.com/fredrikaverpil/neotest-golang/internal/x",
+        Module = {
+          GoMod = tests_filepath .. "/go.mod",
+        },
+        Name = "x",
+        TestGoFiles = { "xtest_whitebox_test.go" },
+        XTestGoFiles = { "xtest_blackbox_test.go" }, -- NOTE: added here because of custom `go list -f` command
+      },
+    }
+
+    assert.are_same(vim.inspect(expected), vim.inspect(first_entry))
+    assert.are_same(expected, first_entry)
+  end)
+end)
+
+describe("go list output from internal/two", function()
+  it("contains two TestGoFiles", function()
+    local tests_filepath = vim.uv.cwd() .. "/tests/go"
+    local filepath = vim.uv.cwd() .. "/tests/go/internal/two"
+    local output = lib.cmd.golist_data(filepath)
+    local first_entry = output
+    local expected = {
+      {
+        Dir = filepath,
+        ImportPath = "github.com/fredrikaverpil/neotest-golang/internal/two",
+        Module = {
+          GoMod = tests_filepath .. "/go.mod",
+        },
+        Name = "two",
+        TestGoFiles = { "one_test.go", "two_test.go" },
+        XTestGoFiles = {}, -- NOTE: added here because of custom `go list -f` command
+      },
+    }
+
+    assert.are_same(vim.inspect(expected), vim.inspect(first_entry))
+    assert.are_same(expected, first_entry)
+  end)
+end)
+
+describe("go list output from internal/notest", function()
+  it("contains no tests", function()
+    local tests_filepath = vim.uv.cwd() .. "/tests/go"
+    local filepath = vim.uv.cwd() .. "/tests/go/internal/notest"
+    local output = lib.cmd.golist_data(filepath)
+    local first_entry = output
+    local expected = {
+      {
+        Dir = filepath,
+        ImportPath = "github.com/fredrikaverpil/neotest-golang/internal/notest",
+        Module = {
+          GoMod = tests_filepath .. "/go.mod",
+        },
+        Name = "notest",
+        TestGoFiles = {}, -- NOTE: added here because of custom `go list -f` command
+        XTestGoFiles = {}, -- NOTE: added here because of custom `go list -f` command
+      },
+    }
 
     assert.are_same(vim.inspect(expected), vim.inspect(first_entry))
     assert.are_same(expected, first_entry)


### PR DESCRIPTION
Although this might add some complexity and template execution, this can substantially reduce the JSON payload size from `go list`. This should mean that `vim.json.decode` won't have as much to do and hopefully this would be a performance gain on huge monorepos.

Related: #245