### PR TITLE
fix: temporary fix for 'go list -json -f ...' on windows

### DIFF
--- a/lua/neotest-golang/lib/cmd.lua
+++ b/lua/neotest-golang/lib/cmd.lua
@@ -54,6 +54,12 @@ function M.golist_command()
     }]],
   }
 
+  -- FIXME: this is a workaround for Windows, where there is a bug with the output
+  -- when using the -f flag: https://github.com/fredrikaverpil/neotest-golang/issues/276
+  if vim.fn.has("win32") == 1 then
+    cmd = { "go", "list", "-json" }
+  end
+
   local go_list_args = options.get().go_list_args
   if type(go_list_args) == "function" then
     go_list_args = go_list_args()


### PR DESCRIPTION
It doesn't properly fix the underlying problem described in #276 but at least the adapter won't crash on Windows now.