### PR TITLE
feat: testify tabletests (named struct variant)

### DIFF
--- a/lua/neotest-golang/features/testify/query.lua
+++ b/lua/neotest-golang/features/testify/query.lua
@@ -42,6 +42,59 @@ M.subtest_query = [[
   ) @test.definition
 ]]
 
+M.table_tests = [[
+  ; query for list table tests
+  (block
+    (short_var_declaration
+      left: (expression_list
+        (identifier) @test.cases
+      )
+      right: (expression_list
+        (composite_literal
+          (literal_value
+            (literal_element
+              (literal_value
+                (keyed_element
+                  (literal_element
+                    (identifier) @test.field.name
+                  )
+                  (literal_element
+                    (interpreted_string_literal) @test.name
+                  )
+                )
+              )
+            ) @test.definition
+          )
+        )
+      )
+    )
+    (for_statement
+      (range_clause
+        left: (expression_list
+          (identifier) @test.case
+        )
+        right: (identifier) @test.cases1 (#eq? @test.cases @test.cases1)
+      )
+      body: (block
+        (expression_statement
+          (call_expression
+            function: (selector_expression
+              operand: (identifier) @test.operand (#match? @test.operand "^[s]$")
+              field: (field_identifier) @test.method (#match? @test.method "^Run$")
+            ) 
+            arguments: (argument_list
+              (selector_expression
+                operand: (identifier) @test.case1 (#eq? @test.case @test.case1)
+                field: (field_identifier) @test.field.name1 (#eq? @test.field.name @test.field.name1)
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+]]
+
 --- Run a TreeSitter query on a file and return the matches.
 --- @param filepath string The path to the file to query
 --- @param query_string string The TreeSitter query string

--- a/lua/neotest-golang/query.lua
+++ b/lua/neotest-golang/query.lua
@@ -304,6 +304,7 @@ function M.detect_tests(file_path)
       .. testify.query.namespace_query
       .. testify.query.test_method_query
       .. testify.query.subtest_query
+      .. testify.query.table_tests
   end
 
   ---@type neotest.Tree

--- a/tests/go/internal/testify/positions_spec.lua
+++ b/tests/go/internal/testify/positions_spec.lua
@@ -158,6 +158,41 @@ describe("With testify_enabled=true", function()
             },
           },
         },
+        {
+          {
+            id = test_filepath .. "::TestExampleTestSuite::TestSubTestOperand3",
+            name = "TestSubTestOperand3",
+            path = test_filepath,
+            type = "test",
+          },
+          {
+            {
+              id = test_filepath
+                .. '::TestExampleTestSuite::TestSubTestOperand3::"foo"',
+              name = '"foo"',
+              path = test_filepath,
+              type = "test",
+            },
+          },
+          {
+            {
+              id = test_filepath
+                .. '::TestExampleTestSuite::TestSubTestOperand3::"bar"',
+              name = '"bar"',
+              path = test_filepath,
+              type = "test",
+            },
+          },
+          {
+            {
+              id = test_filepath
+                .. '::TestExampleTestSuite::TestSubTestOperand3::"baz"',
+              name = '"baz"',
+              path = test_filepath,
+              type = "test",
+            },
+          },
+        },
       },
       {
         {

--- a/tests/go/internal/testify/positions_test.go
+++ b/tests/go/internal/testify/positions_test.go
@@ -94,3 +94,30 @@ func (s *ExampleTestSuite) TestSubTestOperand2() {
 		assert.Equal(s.T(), 10, s.VariableThatShouldStartAtFive)
 	})
 }
+
+// A test method with a subttest, using operand s and sub-tests.
+func (s *ExampleTestSuite) TestSubTestOperand3() {
+	tt := []struct {
+		name  string
+		value int
+	}{
+		{
+			name:  "foo",
+			value: 5,
+		},
+		{
+			name:  "bar",
+			value: 5,
+		},
+		{
+			name:  "baz",
+			value: 5,
+		},
+	}
+	for _, tc := range tt {
+		s.Run(tc.name, func() {
+			s.VariableThatShouldStartAtFive = tc.value
+			assert.Equal(s.T(), 5, s.VariableThatShouldStartAtFive)
+		})
+	}
+}


### PR DESCRIPTION
This aims to introduce one variant of how to write testify table tests.

For some reason, the last test case of the table cannot be invoked by "run nearest test". This must be solved prior to merging. 