### PR TITLE
fix: testify subtest operand not recognized

### DIFF
--- a/lua/neotest-golang/features/testify/query.lua
+++ b/lua/neotest-golang/features/testify/query.lua
@@ -17,7 +17,17 @@ M.namespace_query = [[
         type: (pointer_type
           (type_identifier) @namespace.name )))) @namespace.definition
     name: (field_identifier) @test_function (#match? @test_function "^(Test|Example)") (#not-match? @test.name "^TestMain$")
-  ]]
+]]
+
+M.subtest_query = [[
+   ; query for subtest, like s.Run(), suite.Run()
+  (call_expression
+    function: (selector_expression
+      operand: (identifier) @test.operand (#match? @test.operand "^(s|suite)$")
+      field: (field_identifier) @test.method) (#match? @test.method "^Run$")
+    arguments: (argument_list . (interpreted_string_literal) @test.name))
+    @test.definition
+]]
 
 M.test_method_query = [[
    ; query for test method

--- a/lua/neotest-golang/query.lua
+++ b/lua/neotest-golang/query.lua
@@ -199,6 +199,7 @@ function M.detect_tests(file_path)
     query = query
       .. testify.query.namespace_query
       .. testify.query.test_method_query
+      .. testify.query.subtest_query
   end
 
   ---@type neotest.Tree

--- a/tests/go/internal/testify/positions_spec.lua
+++ b/tests/go/internal/testify/positions_spec.lua
@@ -124,6 +124,40 @@ describe("With testify_enabled=true", function()
             type = "test",
           },
         },
+        {
+          {
+            id = test_filepath .. "::TestExampleTestSuite::TestSubTestOperand1",
+            name = "TestSubTestOperand1",
+            path = test_filepath,
+            type = "test",
+          },
+          {
+            {
+              id = test_filepath
+                .. '::TestExampleTestSuite::TestSubTestOperand1::"subtest"',
+              name = '"subtest"',
+              path = test_filepath,
+              type = "test",
+            },
+          },
+        },
+        {
+          {
+            id = test_filepath .. "::TestExampleTestSuite::TestSubTestOperand2",
+            name = "TestSubTestOperand2",
+            path = test_filepath,
+            type = "test",
+          },
+          {
+            {
+              id = test_filepath
+                .. '::TestExampleTestSuite::TestSubTestOperand2::"subtest"',
+              name = '"subtest"',
+              path = test_filepath,
+              type = "test",
+            },
+          },
+        },
       },
       {
         {

--- a/tests/go/internal/testify/positions_test.go
+++ b/tests/go/internal/testify/positions_test.go
@@ -76,3 +76,21 @@ func TestTrivial(t *testing.T) {
 func (suite *OtherTestSuite) TestOther() {
 	assert.Equal(suite.T(), 5, suite.VariableThatShouldStartAtFive)
 }
+
+// --------------------------------------------------------------------
+
+// A test method with a subttest, using operand suite.
+func (suite *ExampleTestSuite) TestSubTestOperand1() {
+	suite.Run("subtest", func() {
+		suite.VariableThatShouldStartAtFive = 10
+		assert.Equal(suite.T(), 10, suite.VariableThatShouldStartAtFive)
+	})
+}
+
+// A test method with a subttest, using operand s.
+func (s *ExampleTestSuite) TestSubTestOperand2() {
+	s.Run("subtest", func() {
+		s.VariableThatShouldStartAtFive = 10
+		assert.Equal(s.T(), 10, s.VariableThatShouldStartAtFive)
+	})
+}


### PR DESCRIPTION
As brought up in #275, the ability to use operand `s` in `s.Run` was removed by mistake in commit bd8e69ea606237c5e441f72ccf67fa774858b5dd.

I'm here bringing it back. However, I'm not sure if table tests can be supported easily. At least it will be handled, separately in #280 