### PR TITLE
ci: skip windows

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         go-version: [1.24] # rc versions are defined like 1.24.0-rc.3
     env:
       GOTOOLCHAIN: local

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   nvim:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         version: [stable, nightly]
     runs-on: ${{ matrix.os }}
     steps:
@@ -34,7 +34,7 @@ jobs:
   go-test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         go-version: [1.24] # rc versions are defined like 1.24.0-rc.3
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
Running `go list` on Windows is flaky for some reason. Seems to timeout
testing etc. Disabling here and can be enabled when needed.
