### PR TITLE
feat: better build error detection (go 1.24)

### DIFF
--- a/lua/neotest-golang/process.lua
+++ b/lua/neotest-golang/process.lua
@@ -257,7 +257,7 @@ function M.build_failure_lookup(
   end
 
   if not build_fail_found then
-    -- Go version below 1.24, resort to old behavior
+    -- Go version is below 1.24 (no build-fail action exists), resort to old behavior
     local output = {}
     if runner == "go" then
       output = gotest_output

--- a/lua/neotest-golang/process.lua
+++ b/lua/neotest-golang/process.lua
@@ -457,8 +457,7 @@ function M.decorate_with_go_test_results(res, gotest_output)
         then
           -- NOTE: for some reason, when sanitizing output, the above success case is not hit.
           test_data.status = "passed"
-        elseif line.Action == "build-fail" then
-          line.Output = "WHOHEY BUILD FAIL"
+        elseif line.Action == "build-fail" then -- introduced in Go 1.24
           test_data.status = "failed"
         elseif line.Action == "fail" then
           test_data.status = "failed"


### PR DESCRIPTION
### Why?

With go 1.24, new build falure information is part of `go test -json`. By reading this information, more accurate build error messages can be shown.

### What?

Add to the existing error handling, build failure messages.


