### PR TITLE
fix: missing outputs while debugging tests

### DIFF
--- a/lua/neotest-golang/features/dap/dap_go.lua
+++ b/lua/neotest-golang/features/dap/dap_go.lua
@@ -41,6 +41,7 @@ function M.get_dap_config(test_path, test_name_regex)
     request = "launch",
     mode = "test",
     program = test_path,
+    outputMode = "remote",
   }
 
   if test_name_regex ~= nil then


### PR DESCRIPTION
I wasn't getting any logs on my repl, adding outputMode=remote fixed the problem.

Based on the following PR of nvim-dap-go: [PR link](https://github.com/leoluz/nvim-dap-go/pull/109)