### PR TITLE
fix: query to support parsing tests using testify suite.T().Run() in loop

### DIFF
--- a/lua/neotest-golang/query.lua
+++ b/lua/neotest-golang/query.lua
@@ -246,10 +246,10 @@ M.table_tests_map = [[
           (literal_value
             (keyed_element
               (literal_element
-                (interpreted_string_literal)  @test.name
+                (interpreted_string_literal) @test.name
               )
               (literal_element
-                (literal_value)  @test.definition
+                (literal_value) @test.definition
               )
             )
           )
@@ -257,30 +257,35 @@ M.table_tests_map = [[
       )
     )
     (for_statement
-       (range_clause
-          left: (expression_list
-            (
-              (identifier) @test.key.name
-            )
-            (
-              (identifier) @test.case
-            )
-          )
-          right: (identifier) @test.cases1 (#eq? @test.cases @test.cases1)
-        )
-        body: (block
-         (expression_statement
-          (call_expression
-            function: (selector_expression
-              operand: (identifier) @test.operand (#match? @test.operand "^[t]$")
-              field: (field_identifier) @test.method (#match? @test.method "^Run$")
+      (range_clause
+        left: (expression_list (identifier) @test.key.name (identifier) @test.case)
+        right: (identifier) @test.cases1 (#eq? @test.cases @test.cases1)
+      )
+      body: (block
+        (expression_statement
+          (call_expression ;; The Run(...) call
+            function: (selector_expression ;; The receiver.Run part
+              operand: [ ;; ALTERNATIVE receivers
+                ;; Case 1: Simple identifier 't'
+                (identifier) @run.receiver.simple (#match? @run.receiver.simple "^t$")
+                ;; Case 2: Result of a call like s.T()
+                (call_expression
+                  function: (selector_expression
+                    operand: (identifier) @suite.var ;; 's'
+                    field: (field_identifier) @suite.t_method (#match? @suite.t_method "^T$") ;; '.T'
+                  )
+                  arguments: (argument_list) ;; ()
+                ) @run.receiver.suite_t
+              ]
+              field: (field_identifier) @test.method (#match? @test.method "^Run$") ;; '.Run'
             )
             arguments: (argument_list
-              (
-                (identifier) @test.key.name1 (#eq? @test.key.name @test.key.name1)
-              )
+              ;; First argument: map key variable
+              (identifier) @test.key.name1 (#eq? @test.key.name @test.key.name1)
+              ;; Second argument: function literal
+              (func_literal) @test.func_body
             )
-          )
+          ) @test.run_call
         )
       )
     )

--- a/tests/go/internal/testify/positions_spec.lua
+++ b/tests/go/internal/testify/positions_spec.lua
@@ -66,6 +66,14 @@ describe("With testify_enabled=false", function()
           type = "test",
         },
       },
+      {
+        {
+          id = test_filepath .. '::"subtest1"',
+          name = '"subtest1"',
+          path = test_filepath,
+          type = "test",
+        },
+      },
     }
 
     -- Act
@@ -153,6 +161,24 @@ describe("With testify_enabled=true", function()
               id = test_filepath
                 .. '::TestExampleTestSuite::TestSubTestOperand2::"subtest"',
               name = '"subtest"',
+              path = test_filepath,
+              type = "test",
+            },
+          },
+        },
+        {
+          {
+            id = test_filepath
+              .. "::TestExampleTestSuite::TestTableSubtestsWithMapAndStruct",
+            name = "TestTableSubtestsWithMapAndStruct",
+            path = test_filepath,
+            type = "test",
+          },
+          {
+            {
+              id = test_filepath
+                .. '::TestExampleTestSuite::TestTableSubtestsWithMapAndStruct::"subtest1"',
+              name = '"subtest1"',
               path = test_filepath,
               type = "test",
             },

--- a/tests/go/internal/testify/positions_test.go
+++ b/tests/go/internal/testify/positions_test.go
@@ -104,10 +104,6 @@ func (s *ExampleTestSuite) TestTableSubtestsWithMapAndStruct() {
 			a: 1,
 			b: "one",
 		},
-		"subtest2": {
-			a: 2,
-			b: "two",
-		},
 	}
 
 	for name, tc := range tests {

--- a/tests/go/internal/testify/positions_test.go
+++ b/tests/go/internal/testify/positions_test.go
@@ -94,3 +94,25 @@ func (s *ExampleTestSuite) TestSubTestOperand2() {
 		assert.Equal(s.T(), 10, s.VariableThatShouldStartAtFive)
 	})
 }
+
+func (s *ExampleTestSuite) TestTableSubtestsWithMapAndStruct() {
+	tests := map[string]struct {
+		a int
+		b string
+	}{
+		"subtest1": {
+			a: 1,
+			b: "one",
+		},
+		"subtest2": {
+			a: 2,
+			b: "two",
+		},
+	}
+
+	for name, tc := range tests {
+		s.T().Run(name, func(t *testing.T) {
+			assert.Equal(t, 3, len(tc.b))
+		})
+	}
+}


### PR DESCRIPTION
fixes #328 