### PR TITLE
ci(dependabot): sync with fredrikaverpil/github

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,19 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
-    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "gomod"
+    directories: ["./tools"]
+    allow:
+      - dependency-type: indirect
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      go-tools:
+        patterns: ["*"]
     labels:
       - "dependencies"
 
@@ -25,14 +37,12 @@ updates:
       uv-minor-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]
-    open-pull-requests-limit: 10
     labels:
       - "dependencies"
 
   - package-ecosystem: "gomod"
     directories:
       - tests/go
-      - tools
     schedule:
       interval: "weekly"
       day: "monday"
@@ -40,13 +50,12 @@ updates:
       gomod-minor-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]
-    open-pull-requests-limit: 10
     labels:
       - "dependencies"
 
   - package-ecosystem: "cargo"
     directories:
-      - tools
+
     schedule:
       interval: "weekly"
       day: "monday"
@@ -54,6 +63,5 @@ updates:
       cargo-minor-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]
-    open-pull-requests-limit: 10
     labels:
       - "dependencies"


### PR DESCRIPTION
This PR syncs the GitHub repo with a generated `dependabot.yml` from the [fredrikaverpil/github](https://github.com/fredrikaverpil/github) repository.