### PR TITLE
fix(convert): correct regex passed to go test -run for single test execution

### DIFF
--- a/lua/neotest-golang/lib/convert.lua
+++ b/lua/neotest-golang/lib/convert.lua
@@ -22,6 +22,9 @@ function M.to_gotest_regex_pattern(test_name)
     "^",
     "$",
   }
+  for _, character in ipairs(special_characters) do
+    test_name = test_name:gsub("%" .. character, "\\" .. character)
+  end
   -- Each segment separated by '/' must be wrapped in an exact regex match.
   -- From Go docs:
   --    For tests, the regular expression is split by unbracketed
@@ -30,9 +33,6 @@ function M.to_gotest_regex_pattern(test_name)
   --    the sequence, if any.
   local segments = {}
   for segment in string.gmatch(test_name, "[^/]+") do
-    for _, character in ipairs(special_characters) do
-      segment = segment:gsub("%" .. character, "\\" .. character)
-    end
     table.insert(segments, "^" .. segment .. "$")
   end
 

--- a/lua/neotest-golang/lib/convert.lua
+++ b/lua/neotest-golang/lib/convert.lua
@@ -22,13 +22,13 @@ function M.to_gotest_regex_pattern(test_name)
     "^",
     "$",
   }
--- Each segment separated by '/' must be wrapped in an exact regex match.
--- From Go docs:
---    For tests, the regular expression is split by unbracketed
---    slash (/) characters into a sequence of regular expressions, and each
---    part of a test's identifier must match the corresponding element in
---    the sequence, if any.
-local segments = {}
+  -- Each segment separated by '/' must be wrapped in an exact regex match.
+  -- From Go docs:
+  --    For tests, the regular expression is split by unbracketed
+  --    slash (/) characters into a sequence of regular expressions, and each
+  --    part of a test's identifier must match the corresponding element in
+  --    the sequence, if any.
+  local segments = {}
   for segment in string.gmatch(test_name, "[^/]+") do
     for _, character in ipairs(special_characters) do
       segment = segment:gsub("%" .. character, "\\" .. character)

--- a/lua/neotest-golang/lib/convert.lua
+++ b/lua/neotest-golang/lib/convert.lua
@@ -22,10 +22,21 @@ function M.to_gotest_regex_pattern(test_name)
     "^",
     "$",
   }
-  for _, character in ipairs(special_characters) do
-    test_name = test_name:gsub("%" .. character, "\\" .. character)
+-- Each segment separated by '/' must be wrapped in an exact regex match.
+-- From Go docs:
+--    For tests, the regular expression is split by unbracketed
+--    slash (/) characters into a sequence of regular expressions, and each
+--    part of a test's identifier must match the corresponding element in
+--    the sequence, if any.
+local segments = {}
+  for segment in string.gmatch(test_name, "[^/]+") do
+    for _, character in ipairs(special_characters) do
+      segment = segment:gsub("%" .. character, "\\" .. character)
+    end
+    table.insert(segments, "^" .. segment .. "$")
   end
-  return "^" .. test_name .. "$"
+
+  return table.concat(segments, "/")
 end
 
 -- Converts the AST-detected Neotest node test name into the 'go test' command

--- a/tests/go/internal/testname/testname_spec.lua
+++ b/tests/go/internal/testname/testname_spec.lua
@@ -94,18 +94,38 @@ describe("Full Go test name conversion", function()
   local tree =
     nio.tests.with_async_context(adapter.discover_positions, test_filepath)
 
-  it("escapes parenthesis", function()
-    local expected_subtest_name = '"Test(success)"'
-    local expected_gotest_name = "^TestNames/Test\\(success\\)$"
+  local tests = {
+    {
+      description = "escapes parenthesis",
+      node_index = 7,
+      expected_subtest_name = '"Test(success)"',
+      expected_gotest_name = "^TestNames$/^Test\\(success\\)$",
+    },
+    {
+      description = "wrap single test in exact regex",
+      node_index = 2,
+      expected_subtest_name = "TestNames",
+      expected_gotest_name = "^TestNames$",
+    },
+    {
+      description = "wrap doubly nested test in exact regex",
+      node_index = 10,
+      expected_subtest_name = '"nested2"',
+      expected_gotest_name = "^TestNames$/^nested1$/^nested2$",
+    },
+  }
 
-    -- Act
-    local pos = tree:node(7):data()
-    local test_name = lib.convert.to_gotest_test_name(pos.id)
-    test_name = lib.convert.to_gotest_regex_pattern(test_name)
+  for _, tc in ipairs(tests) do
+    it(tc.description, function()
+      local pos = tree:node(tc.node_index):data()
+      local test_name = lib.convert.to_gotest_test_name(pos.id)
+      test_name = lib.convert.to_gotest_regex_pattern(test_name)
 
-    -- Assert
-    local actual_name = pos.name
-    assert.are.same(expected_subtest_name, actual_name)
-    assert.are.same(vim.inspect(expected_gotest_name), vim.inspect(test_name))
-  end)
+      assert.are.same(tc.expected_subtest_name, pos.name)
+      assert.are.same(
+        vim.inspect(tc.expected_gotest_name),
+        vim.inspect(test_name)
+      )
+    end)
+  end
 end)

--- a/tests/go/internal/testname/testname_test.go
+++ b/tests/go/internal/testname/testname_test.go
@@ -39,12 +39,4 @@ func TestNames(t *testing.T) {
 			t.Fail()
 		}
 	})
-
-	t.Run("nested1", func(t *testing.T) {
-		t.Run("nested2", func(t *testing.T) {
-			if Add(1, 2) != 3 {
-				t.Fail()
-			}
-		})
-	})
 }

--- a/tests/go/internal/testname/testname_test.go
+++ b/tests/go/internal/testname/testname_test.go
@@ -39,4 +39,12 @@ func TestNames(t *testing.T) {
 			t.Fail()
 		}
 	})
+
+	t.Run("nested1", func(t *testing.T) {
+		t.Run("nested2", func(t *testing.T) {
+			if Add(1, 2) != 3 {
+				t.Fail()
+			}
+		})
+	})
 }


### PR DESCRIPTION
Solves https://github.com/fredrikaverpil/neotest-golang/issues/339