### PR TITLE
ci: avoid duplicate triggers

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,8 +1,5 @@
 name: luarocks
 on:
-  push:
-    tags:
-      - '*'
   release:
     types:
       - created


### PR DESCRIPTION
The luarocks deployment keeps getting triggered twice when releasing, causing this status:

<img width="262" alt="image" src="https://github.com/user-attachments/assets/a762b168-4ae8-4576-9a67-b50f3405e341" />
