### PR TITLE
feat: add streaming support

### DIFF
--- a/lua/neotest-golang/init.lua
+++ b/lua/neotest-golang/init.lua
@@ -105,12 +105,12 @@ function M.Adapter.build_spec(args)
     -- A runspec is to be created, based on running all tests in the given
     -- directory. In this case, the directory is also the current working
     -- directory.
-    return runspec.dir.build(pos)
+    return runspec.dir.build(pos, tree)
   elseif pos.type == "dir" then
     -- A runspec is to be created, based on running all tests in the given
     -- directory. In this case, the directory is a sub-directory of the current
     -- working directory.
-    return runspec.dir.build(pos)
+    return runspec.dir.build(pos, tree)
   elseif pos.type == "file" then
     -- A runspec is to be created, based on on running all tests in the given
     -- file.
@@ -118,10 +118,10 @@ function M.Adapter.build_spec(args)
   elseif pos.type == "namespace" then
     -- A runspec is to be created, based on running all tests in the given
     -- namespace.
-    return runspec.namespace.build(pos)
+    return runspec.namespace.build(pos, tree)
   elseif pos.type == "test" then
     -- A runspec is to be created, based on on running the given test.
-    return runspec.test.build(pos, args.strategy)
+    return runspec.test.build(pos, tree, args.strategy)
   end
 
   logger.error(

--- a/lua/neotest-golang/lib/init.lua
+++ b/lua/neotest-golang/lib/init.lua
@@ -6,5 +6,6 @@ M.find = require("neotest-golang.lib.find")
 M.json = require("neotest-golang.lib.json")
 M.sanitize = require("neotest-golang.lib.sanitize")
 M.string = require("neotest-golang.lib.string")
+M.stream = require("neotest-golang.lib.stream")
 
 return M

--- a/lua/neotest-golang/lib/stream.lua
+++ b/lua/neotest-golang/lib/stream.lua
@@ -1,3 +1,4 @@
+local convert = require("neotest-golang.lib.convert")
 local json = require("neotest-golang.lib.json")
 local logger = require("neotest-golang.logging")
 local options = require("neotest-golang.options")
@@ -6,12 +7,21 @@ local neotest_lib = require("neotest.lib")
 
 local M = {}
 
+--- Convert to internal and unique test id for lookup.
+local function to_test_id(package_name, test_name)
+  return package_name .. "::" .. test_name
+end
+
 --- Contstructor for new stream.
+--- @param golist_data table Golist data containing package information
 ---@param json_filepath string|nil Path to the JSON output file
 ---@return function, function
-function M.new(json_filepath)
-  local stream_data = function() end
-  local stop_stream = function() end
+function M.new(tree, golist_data, json_filepath)
+  -- vim.notify(vim.inspect("New stream!"))
+
+  M.accumulated_test_data = {} -- reset
+  local stream_data = function() end -- no-op
+  local stop_stream = function() end -- no-op
   if options.get().runner == "gotestsum" then
     if json_filepath ~= nil then
       neotest_lib.files.write(json_filepath, "") -- ensure the file exists
@@ -24,48 +34,83 @@ function M.new(json_filepath)
   --- Stream function.
   ---@param data function A function that returns a table of strings, each representing a line of JSON output.
   local function stream(data)
+    local tree = tree
+    local golist_data = golist_data
+    local json_lines = {}
+    local accum = {}
+
+    ---@type table<string, neotest.Result>
+    local results = {}
+
     return function()
-      local json_lines = {}
-      local results = {}
+      local lines = {}
       if options.get().runner == "go" then
-        local lines = data() -- capture from stdout
-        for _, line in ipairs(lines) do
-          json_lines =
-            vim.list_extend(json_lines, json.decode_from_string(line))
-        end
+        lines = data() -- capture from stdout
       elseif options.get().runner == "gotestsum" then
-        local lines = stream_data() -- capture from stream
-        for _, line in ipairs(lines) do
-          json_lines = json.decode_from_string(line)
+        lines = stream_data() -- capture from stream
+      end
+
+      for _, line in ipairs(lines) do
+        json_lines = vim.list_extend(json_lines, json.decode_from_string(line))
+        for _, json_line in ipairs(json_lines) do
+          accum = M.process_event(tree, golist_data, accum, json_line)
         end
       end
 
-      for _, json_line in ipairs(json_lines) do
-        -- started test detected
-        if json_line.Action == "start" and json_line.Test ~= nil then
-          vim.notify(vim.inspect(json_line))
-          -- TODO: store ongoing test in lookup table
-        end
-
-        -- running test detected
-        if json_line.Action == "output" and json_line.Test ~= nil then
-          vim.notify(vim.inspect(json_line))
-          -- TODO: store ongoing test in lookup table
-        end
-
-        -- passed test
-        if json_line.Action == "pass" and json_line.Test ~= nil then
-          vim.notify("PASS: " .. vim.inspect(json_line))
-          -- TODO: map test/package to position id, add to results when all started tests have a status
+      for _, test_data in pairs(accum) do
+        if test_data.status == "passed" then
+          results[test_data.position_id] = {
+            status = test_data.status, -- passed/failed/skipped
+            output = test_data.output,
+            -- TODO: add short
+            -- TODO: add errors
+          }
         end
       end
 
-      -- TODO: return results only if all ongoign tests have a status
+      -- TODO: only return a result when a test has a status (pass/fail/skip), otherwise return {}
       return results
     end
   end
 
   return stream, stop_stream
+end
+
+--- Process a single event from the test output.
+--- @param accum table Accumulated test data.
+--- @param e table The event data.
+function M.process_event(tree, golist_data, accum, e)
+  -- TODO: do we want to do something with 'start' status?
+
+  -- Indicate test started/running.
+  if e.Action == "run" and e.Test ~= nil then
+    local id = to_test_id(e.Package, e.Test)
+    accum[id] = { status = "running", output = "" }
+    if e.Output ~= nil then
+      accum[id].output = e.Output
+    end
+  end
+
+  -- Record output.
+  if e.Action == "output" and e.Test ~= nil and e.Output ~= nil then
+    local id = to_test_id(e.Package, e.Test)
+    accum[id].output = accum[id].output .. "\n" .. e.Output
+  end
+
+  -- Passed test.
+  if e.Action == "pass" and e.Test ~= nil then
+    local id = to_test_id(e.Package, e.Test)
+    accum[id].status = "passed"
+    if e.Output ~= nil then
+      accum[id].output = e.Output
+    end
+
+    local pattern =
+      convert.to_position_id_pattern(golist_data, e.Package, e.Test)
+    accum[id].position_id = convert.to_position_id(tree, pattern)
+  end
+
+  return accum
 end
 
 return M

--- a/lua/neotest-golang/lib/stream.lua
+++ b/lua/neotest-golang/lib/stream.lua
@@ -1,0 +1,71 @@
+local json = require("neotest-golang.lib.json")
+local logger = require("neotest-golang.logging")
+local options = require("neotest-golang.options")
+
+local neotest_lib = require("neotest.lib")
+
+local M = {}
+
+--- Contstructor for new stream.
+---@param json_filepath string|nil Path to the JSON output file
+---@return function, function
+function M.new(json_filepath)
+  local stream_data = function() end
+  local stop_stream = function() end
+  if options.get().runner == "gotestsum" then
+    if json_filepath ~= nil then
+      neotest_lib.files.write(json_filepath, "") -- ensure the file exists
+      stream_data, stop_stream = neotest_lib.files.stream_lines(json_filepath)
+    else
+      logger.error("JSON filepath is required for gotestsum runner streaming")
+    end
+  end
+
+  --- Stream function.
+  ---@param data function A function that returns a table of strings, each representing a line of JSON output.
+  local function stream(data)
+    return function()
+      local json_lines = {}
+      local results = {}
+      if options.get().runner == "go" then
+        local lines = data() -- capture from stdout
+        for _, line in ipairs(lines) do
+          json_lines =
+            vim.list_extend(json_lines, json.decode_from_string(line))
+        end
+      elseif options.get().runner == "gotestsum" then
+        local lines = stream_data() -- capture from stream
+        for _, line in ipairs(lines) do
+          json_lines = json.decode_from_string(line)
+        end
+      end
+
+      for _, json_line in ipairs(json_lines) do
+        -- started test detected
+        if json_line.Action == "start" and json_line.Test ~= nil then
+          vim.notify(vim.inspect(json_line))
+          -- TODO: store ongoing test in lookup table
+        end
+
+        -- running test detected
+        if json_line.Action == "output" and json_line.Test ~= nil then
+          vim.notify(vim.inspect(json_line))
+          -- TODO: store ongoing test in lookup table
+        end
+
+        -- passed test
+        if json_line.Action == "pass" and json_line.Test ~= nil then
+          vim.notify("PASS: " .. vim.inspect(json_line))
+          -- TODO: map test/package to position id, add to results when all started tests have a status
+        end
+      end
+
+      -- TODO: return results only if all ongoign tests have a status
+      return results
+    end
+  end
+
+  return stream, stop_stream
+end
+
+return M

--- a/lua/neotest-golang/process.lua
+++ b/lua/neotest-golang/process.lua
@@ -13,6 +13,7 @@ local options = require("neotest-golang.options")
 --- @field errors? table<string> Non-gotest errors to show in the final output.
 --- @field is_dap_active boolean? If true, parsing of test output will occur.
 --- @field test_output_json_filepath? string Gotestsum JSON filepath.
+--- @field stop_stream fun() Stops the stream of test output.
 
 --- @class TestData
 --- @field status neotest.ResultStatus
@@ -39,6 +40,8 @@ function M.test_results(spec, result, tree)
 
   --- @type RunspecContext
   local context = spec.context
+
+  spec.context.stop_stream()
 
   --- Final Neotest results, the way Neotest wants it returned.
   --- @type table<string, neotest.Result>

--- a/lua/neotest-golang/runspec/dir.lua
+++ b/lua/neotest-golang/runspec/dir.lua
@@ -112,12 +112,15 @@ function M.build(pos)
     env = env()
   end
 
+  local stream, stop_stream = lib.stream.new(json_filepath)
+
   --- @type RunspecContext
   local context = {
     pos_id = pos.id,
     golist_data = golist_data,
     errors = errors,
     test_output_json_filepath = json_filepath,
+    stop_stream = stop_stream,
   }
 
   --- @type neotest.RunSpec
@@ -126,6 +129,7 @@ function M.build(pos)
     cwd = pos.path,
     context = context,
     env = env,
+    stream = stream,
   }
 
   logger.debug({ "RunSpec:", run_spec })

--- a/lua/neotest-golang/runspec/dir.lua
+++ b/lua/neotest-golang/runspec/dir.lua
@@ -79,7 +79,7 @@ end
 --- 3. Use the relative path from the go.mod file to pos.path as the test pattern.
 --- @param pos neotest.Position
 --- @return neotest.RunSpec | nil
-function M.build(pos)
+function M.build(pos, tree)
   local go_mod_filepath = lib.find.file_upwards("go.mod", pos.path)
   if go_mod_filepath == nil then
     logger.error(
@@ -112,7 +112,7 @@ function M.build(pos)
     env = env()
   end
 
-  local stream, stop_stream = lib.stream.new(json_filepath)
+  local stream, stop_stream = lib.stream.new(tree, golist_data, json_filepath)
 
   --- @type RunspecContext
   local context = {

--- a/lua/neotest-golang/runspec/file.lua
+++ b/lua/neotest-golang/runspec/file.lua
@@ -91,7 +91,7 @@ function M.build(pos, tree, strategy)
     env = env()
   end
 
-  local stream, stop_stream = lib.stream.new(json_filepath)
+  local stream, stop_stream = lib.stream.new(tree, golist_data, json_filepath)
 
   --- @type RunspecContext
   local context = {

--- a/lua/neotest-golang/runspec/file.lua
+++ b/lua/neotest-golang/runspec/file.lua
@@ -91,12 +91,15 @@ function M.build(pos, tree, strategy)
     env = env()
   end
 
+  local stream, stop_stream = lib.stream.new(json_filepath)
+
   --- @type RunspecContext
   local context = {
     pos_id = pos.id,
     golist_data = golist_data,
     errors = errors,
     test_output_json_filepath = json_filepath,
+    stop_stream = stop_stream,
   }
 
   --- @type neotest.RunSpec
@@ -105,6 +108,7 @@ function M.build(pos, tree, strategy)
     cwd = pos_path_folderpath,
     context = context,
     env = env,
+    stream = stream,
   }
 
   if runspec_strategy ~= nil then

--- a/lua/neotest-golang/runspec/namespace.lua
+++ b/lua/neotest-golang/runspec/namespace.lua
@@ -35,12 +35,15 @@ function M.build(pos)
     env = env()
   end
 
+  local stream, stop_stream = lib.stream.new(json_filepath)
+
   --- @type RunspecContext
   local context = {
     pos_id = pos.id,
     golist_data = golist_data,
     errors = errors,
     test_output_json_filepath = json_filepath,
+    stop_stream = stop_stream,
   }
 
   --- @type neotest.RunSpec
@@ -49,6 +52,7 @@ function M.build(pos)
     cwd = pos_path_folderpath,
     context = context,
     env = env,
+    stream = stream,
   }
 
   logger.debug({ "RunSpec:", run_spec })

--- a/lua/neotest-golang/runspec/namespace.lua
+++ b/lua/neotest-golang/runspec/namespace.lua
@@ -10,7 +10,7 @@ local M = {}
 --- Build runspec for a single test
 --- @param pos neotest.Position
 --- @return neotest.RunSpec | neotest.RunSpec[] | nil
-function M.build(pos)
+function M.build(pos, tree)
   local pos_path_folderpath =
     string.match(pos.path, "(.+)" .. lib.find.os_path_sep)
 
@@ -35,7 +35,7 @@ function M.build(pos)
     env = env()
   end
 
-  local stream, stop_stream = lib.stream.new(json_filepath)
+  local stream, stop_stream = lib.stream.new(tree, golist_data, json_filepath)
 
   --- @type RunspecContext
   local context = {

--- a/lua/neotest-golang/runspec/test.lua
+++ b/lua/neotest-golang/runspec/test.lua
@@ -46,6 +46,8 @@ function M.build(pos, strategy)
     env = env()
   end
 
+  local stream, stop_stream = lib.stream.new(json_filepath)
+
   --- @type RunspecContext
   local context = {
     pos_id = pos.id,
@@ -53,6 +55,7 @@ function M.build(pos, strategy)
     errors = errors,
     process_test_results = true,
     test_output_json_filepath = json_filepath,
+    stop_stream = stop_stream,
   }
 
   --- @type neotest.RunSpec
@@ -61,6 +64,7 @@ function M.build(pos, strategy)
     cwd = pos_path_folderpath,
     context = context,
     env = env,
+    stream = stream,
   }
 
   if runspec_strategy ~= nil then

--- a/lua/neotest-golang/runspec/test.lua
+++ b/lua/neotest-golang/runspec/test.lua
@@ -12,7 +12,7 @@ local M = {}
 --- @param pos neotest.Position
 --- @param strategy string
 --- @return neotest.RunSpec | neotest.RunSpec[] | nil
-function M.build(pos, strategy)
+function M.build(pos, tree, strategy)
   local pos_path_folderpath = vim.fn.fnamemodify(pos.path, ":h")
 
   local golist_data, golist_error = lib.cmd.golist_data(pos_path_folderpath)
@@ -46,7 +46,7 @@ function M.build(pos, strategy)
     env = env()
   end
 
-  local stream, stop_stream = lib.stream.new(json_filepath)
+  local stream, stop_stream = lib.stream.new(tree, golist_data, json_filepath)
 
   --- @type RunspecContext
   local context = {


### PR DESCRIPTION
### Why?

Streaming allows for quicker, near-realtime, feedback on individual test results when running a large test suite.

As a side-effect, this might actually open up for the potential ability to detect tests in runtime, that could not be detected by AST parsing.

### What?

- Add streaming capability.
- Refactor output processing completely.
