### PR TITLE
fix(init): fixes to bootstrap and minimal_init

### DIFF
--- a/spec/minimal_init.lua
+++ b/spec/minimal_init.lua
@@ -1,10 +1,23 @@
 local M = {}
 
 --- Initialize before running each test.
+--- Also see bootstrap.lua which runs once before all tests.
 function M.init()
   vim.cmd([[set runtimepath=$VIMRUNTIME]]) -- reset, otherwise it contains all of $PATH
+
+  local site_dir = ".tests/all/site"
+
+  vim.opt.runtimepath:append(".") -- add project root to runtime path so we can require our adapter
+  vim.opt.runtimepath:append(site_dir) -- add site directory to runtime path so neovim can find parsers
+  vim.opt.packpath = { site_dir } -- add site directory to packpath so plugins can be found
   vim.opt.swapfile = false
-  vim.opt.packpath = { ".tests/all/site" } -- set packpath to the site directory
+
+  -- Add all the plugins to runtime path (they should already be downloaded by bootstrap)
+  local plugins = { "plenary.nvim", "nvim-nio", "nvim-treesitter", "neotest" }
+  for _, plugin in ipairs(plugins) do
+    local plugin_path = site_dir .. "/pack/deps/start/" .. plugin
+    vim.opt.runtimepath:append(plugin_path)
+  end
 end
 
 M.init()


### PR DESCRIPTION
This cleans up and conforms the bootstrap (one-time) and init (per-test)
scripts. Additions involves making sure we are placing the adapter and
plugins on runtimepath. Plugins are also added to packpath.
