### PR TITLE
fix: windows support

### DIFF
--- a/.github/workflows/nvim-plenary.yml
+++ b/.github/workflows/nvim-plenary.yml
@@ -11,7 +11,7 @@ jobs:
   plenary:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         version: [stable, nightly]
     runs-on: ${{ matrix.os }}
     steps:
@@ -33,9 +33,41 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: tests/go/go.mod
-          cache: true
-          cache-dependency-path: tests/go/go.sum
+          cache: false
+      - name: Cache Go tools
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/bin
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-tools-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-tools-
+      - name: Cache Windows build tools
+        if: runner.os == 'Windows'
+        uses: actions/cache@v4
+        with:
+          path: |
+            C:\ProgramData\chocolatey\lib
+            C:\msys64
+          key: ${{ runner.os }}-build-tools-${{ hashFiles('.github/workflows/nvim-plenary.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-tools-
+      - name: Setup build tools (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          # Check if tools are already installed from cache
+          if (!(Test-Path "C:\msys64\usr\bin\find.exe")) {
+            # Install MinGW for tree-sitter compilation
+            choco install mingw -y
+            # Install MSYS2 which includes GNU find and other Unix tools
+            choco install msys2 -y
+          }
+          # Add MSYS2 bin to PATH (this includes GNU find)
+          echo "C:\msys64\usr\bin" >> $env:GITHUB_PATH
       - name: Verify build tools
+        shell: bash
         run: |
           gcc --version
           node --version
@@ -45,13 +77,18 @@ jobs:
       - name: Verify tree-sitter-cli
         run: tree-sitter --version
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@latest
-      - name: go version
-        run: go version
+        shell: bash
+        run: |
+          if ! command -v gotestsum &> /dev/null; then
+            go install gotest.tools/gotestsum@latest
+          else
+            echo "gotestsum already installed"
+          fi
       - name: gotestsum version
         run: gotestsum --version
       - name: Install Task
         uses: go-task/setup-task@v1
       - name: Run tests
+        shell: bash
         run: task test-plenary
 

--- a/.github/workflows/nvim-plenary.yml
+++ b/.github/workflows/nvim-plenary.yml
@@ -86,6 +86,22 @@ jobs:
           fi
       - name: gotestsum version
         run: gotestsum --version
+      - name: "Debug: go list"
+        shell: bash
+        working-directory: tests/go
+        run: |
+          go list -f '{
+          "Dir": {{printf "%q" .Dir}},
+          "ImportPath": "{{.ImportPath}}",
+          "Name": "{{.Name}}",
+          "TestGoFiles": [{{range $i, $f := .TestGoFiles}}{{if ne $i 0}},{{end}}"{{$f}}"{{end}}],
+          "XTestGoFiles": [{{range $i, $f := .XTestGoFiles}}{{if ne $i 0}},{{end}}"{{$f}}"{{end}}],
+          "Module": { "GoMod": {{printf "%q" .Module.GoMod}} }
+          }]' ./...
+      - name: "Debug: go test"
+        shell: bash
+        working-directory: tests/go
+        run: go test -v -json ./... || true
       - name: Install Task
         uses: go-task/setup-task@v1
       - name: Run tests

--- a/.github/workflows/nvim-plenary.yml
+++ b/.github/workflows/nvim-plenary.yml
@@ -106,5 +106,35 @@ jobs:
         uses: go-task/setup-task@v1
       - name: Run tests
         shell: bash
-        run: task test-plenary
+        run: |
+          if ! task test-plenary; then
+            echo "::group::Neovim logs"
+            echo "Tests failed, searching for nvim logs..."
+            
+            # Common nvim log locations across platforms
+            LOG_PATHS=(
+              "$HOME/.local/state/nvim"
+              "$HOME/.cache/nvim"
+              "$HOME/Library/Caches/nvim"
+              "$LOCALAPPDATA/nvim-data"
+              "/tmp"
+              "."
+            )
+            
+            for path in "${LOG_PATHS[@]}"; do
+              if [ -d "$path" ]; then
+                echo "Checking $path for logs..."
+                find "$path" -name "*.log" -type f 2>/dev/null | while read -r logfile; do
+                  if [ -f "$logfile" ]; then
+                    echo "=== $logfile ==="
+                    cat "$logfile" 2>/dev/null || echo "Could not read $logfile"
+                    echo
+                  fi
+                done
+              fi
+            done
+            
+            echo "::endgroup::"
+            exit 1
+          fi
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,6 +5,7 @@ version: '3'
 
 vars:
   TASKFILES:
+    # Note: Uses sh/bash shell even on Windows (available through MSYS2, Git Bash, etc.)
     sh: |
       case "$(uname -s)" in
         CYGWIN*|MINGW32*|MINGW64*|MSYS*)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,7 +5,17 @@ version: '3'
 
 vars:
   TASKFILES:
-    sh: find . -type f -name "Taskfile.*.yml" -not -path "*/node_modules/*" -not -path "*/.git/*" | sort
+    sh: |
+      case "$(uname -s)" in
+        CYGWIN*|MINGW32*|MINGW64*|MSYS*)
+          # Windows - use PowerShell
+          powershell -Command "Get-ChildItem -Recurse -Filter 'Taskfile.*.yml' | Where-Object { \$_.FullName -notmatch 'node_modules|\.git' } | ForEach-Object { \$_.FullName -replace [regex]::Escape((Get-Location).Path), '.' -replace '\\\\', '/' } | Sort-Object"
+          ;;
+        *)
+          # Unix-like (Linux, macOS)
+          find . -name "Taskfile.*.yml" -type f | grep -v node_modules | grep -v .git | sort
+          ;;
+      esac
 
 tasks:
   default:

--- a/lua/neotest-golang/health.lua
+++ b/lua/neotest-golang/health.lua
@@ -67,7 +67,7 @@ function M.go_mod_found()
   local go_mod_filepath = nil
   local filepaths = lib.find.go_test_filepaths(vim.fn.getcwd())
   for _, filepath in ipairs(filepaths) do
-    local start_path = lib.find.get_directory(filepath)
+    local start_path = lib.path.get_directory(filepath)
     go_mod_filepath = lib.find.file_upwards("go.mod", start_path)
     if go_mod_filepath ~= nil then
       ok("Found go.mod file for " .. filepath .. " in " .. go_mod_filepath)
@@ -83,7 +83,7 @@ function M.is_problematic_path()
   local go_mod_filepath = nil
   local filepaths = lib.find.go_test_filepaths(vim.fn.getcwd())
   for _, filepath in ipairs(filepaths) do
-    local start_path = lib.find.get_directory(filepath)
+    local start_path = lib.path.get_directory(filepath)
     go_mod_filepath = lib.find.file_upwards("go.mod", start_path)
     local sysname = vim.uv.os_uname().sysname
     local problematic_paths = {

--- a/lua/neotest-golang/health.lua
+++ b/lua/neotest-golang/health.lua
@@ -67,7 +67,7 @@ function M.go_mod_found()
   local go_mod_filepath = nil
   local filepaths = lib.find.go_test_filepaths(vim.fn.getcwd())
   for _, filepath in ipairs(filepaths) do
-    local start_path = vim.fn.fnamemodify(filepath, ":h")
+    local start_path = lib.find.get_directory(filepath)
     go_mod_filepath = lib.find.file_upwards("go.mod", start_path)
     if go_mod_filepath ~= nil then
       ok("Found go.mod file for " .. filepath .. " in " .. go_mod_filepath)
@@ -83,7 +83,7 @@ function M.is_problematic_path()
   local go_mod_filepath = nil
   local filepaths = lib.find.go_test_filepaths(vim.fn.getcwd())
   for _, filepath in ipairs(filepaths) do
-    local start_path = vim.fn.fnamemodify(filepath, ":h")
+    local start_path = lib.find.get_directory(filepath)
     go_mod_filepath = lib.find.file_upwards("go.mod", start_path)
     local sysname = vim.uv.os_uname().sysname
     local problematic_paths = {

--- a/lua/neotest-golang/lib/convert.lua
+++ b/lua/neotest-golang/lib/convert.lua
@@ -147,7 +147,7 @@ end
 ---@param pos_id string Position ID like "/path/to/file_test.go::TestName" or "D:\\path\\file_test.go::TestName"
 ---@return string|nil File path part before "::" or nil if not found
 function M.extract_file_path_from_pos_id(pos_id)
-  if not pos_id or type(pos_id) ~= "string" then
+  if not pos_id or type(pos_id) ~= "string" or pos_id == "" then
     return nil
   end
 

--- a/lua/neotest-golang/lib/convert.lua
+++ b/lua/neotest-golang/lib/convert.lua
@@ -1,6 +1,7 @@
 local find = require("neotest-golang.lib.find")
 local logger = require("neotest-golang.lib.logging")
 local options = require("neotest-golang.options")
+local path = require("neotest-golang.lib.path")
 require("neotest-golang.lib.types")
 
 local M = {}
@@ -123,7 +124,7 @@ end
 ---@return string|nil Import path or nil if not found
 function M.file_path_to_import_path(file_path, import_to_dir)
   -- Get the directory containing the file using cross-platform path handling
-  local file_dir = find.get_directory(file_path)
+  local file_dir = path.get_directory(file_path)
   if not file_dir or file_dir == "" then
     return nil
   end
@@ -170,40 +171,17 @@ function M.pos_id_to_filename(pos_id)
   end
 
   -- Extract file path using Windows-safe method
-  local file_path = M.extract_file_path_from_pos_id(pos_id)
+  local file_path = path.extract_file_path_from_pos_id(pos_id)
   if
     file_path
     and file_path:match("%.go$")
     and (file_path:match("/") or file_path:match("\\"))
   then
     -- Extract just the filename from the full path using platform-conditional utility
-    return M.get_filename_fast(file_path)
+    return path.get_filename_fast(file_path)
   end
 
   return nil
-end
-
----Platform-conditional filename extraction for optimal performance
----Uses fast vim.fs.basename for POSIX-style paths, safe find.get_filename for Windows-style paths
----@param path string File path to extract filename from
----@return string|nil Filename or nil if path is invalid
-function M.get_filename_fast(path)
-  if not path or type(path) ~= "string" or path == "" then
-    return nil
-  end
-
-  -- Detect Windows-style paths (drive letters, UNC paths, backslashes)
-  local is_windows_path = path:match("^[A-Za-z]:") -- Drive letter
-    or path:match("^\\\\") -- UNC path
-    or path:match("\\") -- Contains backslashes
-
-  if is_windows_path then
-    -- Windows-style path: Use our Windows-safe implementation
-    return find.get_filename(path)
-  else
-    -- POSIX-style path: Use fast built-in C function
-    return vim.fs.basename(path)
-  end
 end
 
 return M

--- a/lua/neotest-golang/lib/convert.lua
+++ b/lua/neotest-golang/lib/convert.lua
@@ -158,8 +158,8 @@ function M.pos_id_to_filename(pos_id)
     and file_path:match("%.go$")
     and (file_path:match("/") or file_path:match("\\"))
   then
-    -- Extract just the filename from the full path using cross-platform method
-    return vim.fs.basename(file_path)
+    -- Extract just the filename from the full path using our Windows-safe utility
+    return find.get_filename(file_path)
   end
 
   return nil

--- a/lua/neotest-golang/lib/convert.lua
+++ b/lua/neotest-golang/lib/convert.lua
@@ -1,3 +1,4 @@
+local find = require("neotest-golang.lib.find")
 local logger = require("neotest-golang.lib.logging")
 local options = require("neotest-golang.options")
 require("neotest-golang.lib.types")
@@ -122,7 +123,7 @@ end
 ---@return string|nil Import path or nil if not found
 function M.file_path_to_import_path(file_path, import_to_dir)
   -- Get the directory containing the file using cross-platform path handling
-  local file_dir = vim.fs.dirname(file_path)
+  local file_dir = find.get_directory(file_path)
   if not file_dir or file_dir == "" then
     return nil
   end

--- a/lua/neotest-golang/lib/convert.lua
+++ b/lua/neotest-golang/lib/convert.lua
@@ -143,6 +143,24 @@ function M.file_path_to_import_path(file_path, import_to_dir)
   return nil
 end
 
+---Extract file path from Neotest position ID (handles Windows drive letters correctly)
+---@param pos_id string Position ID like "/path/to/file_test.go::TestName" or "D:\\path\\file_test.go::TestName"
+---@return string|nil File path part before "::" or nil if not found
+function M.extract_file_path_from_pos_id(pos_id)
+  if not pos_id or type(pos_id) ~= "string" then
+    return nil
+  end
+
+  -- Find the first occurrence of "::" (which separates file path from test path)
+  local separator_pos = pos_id:find("::")
+  if separator_pos then
+    return pos_id:sub(1, separator_pos - 1)
+  end
+
+  -- If no "::" found, treat the entire string as the file path
+  return pos_id
+end
+
 ---Convert Neotest position ID to Go test filename
 ---@param pos_id string Position ID like "/path/to/file_test.go::TestName" or synthetic ID like "github.com/pkg::TestName"
 ---@return string|nil Filename like "file_test.go" or nil if not a file path
@@ -151,8 +169,8 @@ function M.pos_id_to_filename(pos_id)
     return nil
   end
 
-  -- Check if it looks like a file path (ends with ".go" and contains path separators)
-  local file_path = pos_id:match("^([^:]+)")
+  -- Extract file path using Windows-safe method
+  local file_path = M.extract_file_path_from_pos_id(pos_id)
   if
     file_path
     and file_path:match("%.go$")

--- a/lua/neotest-golang/lib/convert.lua
+++ b/lua/neotest-golang/lib/convert.lua
@@ -130,7 +130,7 @@ function M.file_path_to_import_path(file_path, import_to_dir)
 
   -- Find matching import path
   for import_path, dir in pairs(import_to_dir) do
-    if dir == file_dir then
+    if vim.fs.normalize(dir) == vim.fs.normalize(file_dir) then
       return import_path
     end
   end

--- a/lua/neotest-golang/lib/convert.lua
+++ b/lua/neotest-golang/lib/convert.lua
@@ -123,7 +123,6 @@ end
 ---@param import_to_dir table<string, string> Mapping of import paths to directories
 ---@return string|nil Import path or nil if not found
 function M.file_path_to_import_path(file_path, import_to_dir)
-  -- Get the directory containing the file using cross-platform path handling
   local file_dir = path.get_directory(file_path)
   if not file_dir or file_dir == "" then
     return nil
@@ -144,7 +143,7 @@ function M.file_path_to_import_path(file_path, import_to_dir)
   return nil
 end
 
----Extract file path from Neotest position ID (handles Windows drive letters correctly)
+---Extract file path from Neotest position ID
 ---@param pos_id string Position ID like "/path/to/file_test.go::TestName" or "D:\\path\\file_test.go::TestName"
 ---@return string|nil File path part before "::" or nil if not found
 function M.extract_file_path_from_pos_id(pos_id)
@@ -170,7 +169,6 @@ function M.pos_id_to_filename(pos_id)
     return nil
   end
 
-  -- Extract file path using Windows-safe method
   local file_path = path.extract_file_path_from_pos_id(pos_id)
   if
     file_path

--- a/lua/neotest-golang/lib/convert.lua
+++ b/lua/neotest-golang/lib/convert.lua
@@ -121,9 +121,9 @@ end
 ---@param import_to_dir table<string, string> Mapping of import paths to directories
 ---@return string|nil Import path or nil if not found
 function M.file_path_to_import_path(file_path, import_to_dir)
-  -- Get the directory containing the file
-  local file_dir = file_path:match("(.+)/[^/]+$")
-  if not file_dir then
+  -- Get the directory containing the file using cross-platform path handling
+  local file_dir = vim.fs.dirname(file_path)
+  if not file_dir or file_dir == "" then
     return nil
   end
 
@@ -150,11 +150,15 @@ function M.pos_id_to_filename(pos_id)
     return nil
   end
 
-  -- Check if it looks like a file path (contains "/" and ends with ".go")
+  -- Check if it looks like a file path (ends with ".go" and contains path separators)
   local file_path = pos_id:match("^([^:]+)")
-  if file_path and file_path:match("%.go$") and file_path:match("/") then
-    -- Extract just the filename from the full path
-    return file_path:match("([^/]+)$")
+  if
+    file_path
+    and file_path:match("%.go$")
+    and (file_path:match("/") or file_path:match("\\"))
+  then
+    -- Extract just the filename from the full path using cross-platform method
+    return vim.fs.basename(file_path)
   end
 
   return nil

--- a/lua/neotest-golang/lib/diagnostics.lua
+++ b/lua/neotest-golang/lib/diagnostics.lua
@@ -24,7 +24,6 @@ M.assertion_patterns = {
 }
 
 ---Captures both "go:123: message" and "filename.go:123: message" formats
----Updated to handle Windows paths with drive letters, backslashes, and UNC paths
 ---Pattern breakdown: ^%s* (optional whitespace) (.*go) (any chars ending in go) :(%d+): (number) (.*) (message)
 M.go_output_pattern = "^%s*(.*go):(%d+): (.*)"
 

--- a/lua/neotest-golang/lib/diagnostics.lua
+++ b/lua/neotest-golang/lib/diagnostics.lua
@@ -24,7 +24,9 @@ M.assertion_patterns = {
 }
 
 ---Captures both "go:123: message" and "filename.go:123: message" formats
-M.go_output_pattern = "^%s*([%w_%-%.]*go):(%d+): (.*)"
+---Updated to handle Windows paths with drive letters, backslashes, and UNC paths
+---Pattern breakdown: ^%s* (optional whitespace) (.*go) (any chars ending in go) :(%d+): (number) (.*) (message)
+M.go_output_pattern = "^%s*(.*go):(%d+): (.*)"
 
 ---Parse Go test output line and classify as hint or error
 ---@param line string The line to parse
@@ -112,8 +114,13 @@ function M.process_diagnostics(test_entry)
 
   ---@type neotest.Error[]
   local errors = {}
-  local test_filename =
-    convert.pos_id_to_filename(test_entry.metadata.position_id)
+
+  -- Cache filename extraction at test entry level to avoid repeated expensive operations
+  if not test_entry.metadata._cached_filename then
+    test_entry.metadata._cached_filename =
+      convert.pos_id_to_filename(test_entry.metadata.position_id)
+  end
+  local test_filename = test_entry.metadata._cached_filename
   local error_set = {}
 
   -- Process each output part directly

--- a/lua/neotest-golang/lib/dupe.lua
+++ b/lua/neotest-golang/lib/dupe.lua
@@ -5,13 +5,13 @@ local logger = require("neotest-golang.lib.logging")
 
 local M = {}
 
---- Find duplicate subtests within the same parent test
+--- Find duplicate subtests within the same parent test and file
 --- @param tree neotest.Tree The neotest tree structure
 function M.warn_duplicate_tests(tree)
-  -- Build a map of parent test -> list of subtest names
+  -- Build a map of (file_path, parent_test) -> list of subtest names
   local parent_to_subtests = {}
 
-  -- First pass: collect all test positions and organize by parent
+  -- First pass: collect all test positions and organize by parent and file
   for _, node in tree:iter_nodes() do
     local pos = node:data()
     if pos.type == "test" then
@@ -34,19 +34,26 @@ function M.warn_duplicate_tests(tree)
           -- Get the subtest name (last part)
           local subtest_name = parts[#parts]
 
-          -- Initialize parent entry if it doesn't exist
-          if not parent_to_subtests[parent_test_name] then
-            parent_to_subtests[parent_test_name] = {}
-          end
+          -- Extract file path from position ID
+          local file_path = convert.extract_file_path_from_pos_id(pos.id)
+          if file_path then
+            -- Create composite key (file_path + parent_test) to ensure duplicates are only flagged within the same file
+            local composite_key = file_path .. "::" .. parent_test_name
 
-          -- Track this subtest under its parent
-          if not parent_to_subtests[parent_test_name][subtest_name] then
-            parent_to_subtests[parent_test_name][subtest_name] = {}
+            -- Initialize parent entry if it doesn't exist
+            if not parent_to_subtests[composite_key] then
+              parent_to_subtests[composite_key] = {}
+            end
+
+            -- Track this subtest under its parent (within the same file)
+            if not parent_to_subtests[composite_key][subtest_name] then
+              parent_to_subtests[composite_key][subtest_name] = {}
+            end
+            table.insert(
+              parent_to_subtests[composite_key][subtest_name],
+              pos.id
+            )
           end
-          table.insert(
-            parent_to_subtests[parent_test_name][subtest_name],
-            pos.id
-          )
         end
       end
     end
@@ -56,7 +63,9 @@ function M.warn_duplicate_tests(tree)
   local duplicate_set = {}
   local found_duplicates = false
 
-  for parent_test_name, subtests in pairs(parent_to_subtests) do
+  for composite_key, subtests in pairs(parent_to_subtests) do
+    -- Extract parent test name from composite key for display purposes
+    local parent_test_name = composite_key:match("::(.+)$")
     for subtest_name, pos_ids in pairs(subtests) do
       if #pos_ids > 1 then
         found_duplicates = true

--- a/lua/neotest-golang/lib/dupe.lua
+++ b/lua/neotest-golang/lib/dupe.lua
@@ -2,6 +2,7 @@
 
 local convert = require("neotest-golang.lib.convert")
 local logger = require("neotest-golang.lib.logging")
+local path = require("neotest-golang.lib.path")
 
 local M = {}
 
@@ -35,7 +36,7 @@ function M.warn_duplicate_tests(tree)
           local subtest_name = parts[#parts]
 
           -- Extract file path from position ID
-          local file_path = convert.extract_file_path_from_pos_id(pos.id)
+          local file_path = path.extract_file_path_from_pos_id(pos.id)
           if file_path then
             -- Create composite key (file_path + parent_test) to ensure duplicates are only flagged within the same file
             local composite_key = file_path .. "::" .. parent_test_name

--- a/lua/neotest-golang/lib/find.lua
+++ b/lua/neotest-golang/lib/find.lua
@@ -1,76 +1,11 @@
---- Helpers around filepaths.
+--- File system search operations for Go test discovery.
 
 local scandir = require("plenary.scandir")
 
 local logger = require("neotest-golang.lib.logging")
+local path = require("neotest-golang.lib.path")
 
 local M = {}
-
-M.os_path_sep = package.config:sub(1, 1) -- "/" on Unix, "\" on Windows
-
---- Get directory part of a path (Windows-safe replacement for fnamemodify(path, ":h")).
---- Preserves original path separators to avoid Windows path breakage.
---- @param path string File or directory path
---- @return string Directory part of the path
-function M.get_directory(path)
-  if not path or path == "" then
-    return "."
-  end
-
-  -- Handle edge cases
-  if path == "/" or path == "\\" then
-    return path
-  end
-
-  -- Find the last separator (either / or \)
-  local last_sep_pos = 0
-  for i = #path, 1, -1 do
-    local char = path:sub(i, i)
-    if char == "/" or char == "\\" then
-      last_sep_pos = i
-      break
-    end
-  end
-
-  if last_sep_pos == 0 then
-    -- No separator found, it's just a filename
-    return "."
-  elseif last_sep_pos == 1 then
-    -- Root directory
-    return path:sub(1, 1)
-  else
-    -- Return everything before the last separator
-    return path:sub(1, last_sep_pos - 1)
-  end
-end
-
---- Get filename part of a path (Windows-safe replacement for fnamemodify(path, ":t")).
---- Preserves original path separators to avoid Windows path breakage.
---- @param path string File or directory path
---- @return string Filename part of the path
-function M.get_filename(path)
-  if not path or path == "" then
-    return ""
-  end
-
-  -- Find the last separator (either / or \)
-  local last_sep_pos = 0
-  for i = #path, 1, -1 do
-    local char = path:sub(i, i)
-    if char == "/" or char == "\\" then
-      last_sep_pos = i
-      break
-    end
-  end
-
-  if last_sep_pos == 0 then
-    -- No separator found, return the whole string
-    return path
-  else
-    -- Return everything after the last separator
-    return path:sub(last_sep_pos + 1)
-  end
-end
 
 --- Find a file upwards in the directory tree and return its path, if found.
 --- @param filename string Name of file to search for
@@ -79,20 +14,20 @@ end
 function M.file_upwards(filename, start_path)
   -- Ensure start_path is a directory
   local start_dir = vim.fn.isdirectory(start_path) == 1 and start_path
-    or M.get_directory(start_path)
+    or path.get_directory(start_path)
   local home_dir = vim.fn.expand("$HOME")
 
   while start_dir ~= home_dir do
     logger.debug("Searching for " .. filename .. " in " .. start_dir)
 
-    local try_path = start_dir .. M.os_path_sep .. filename
+    local try_path = start_dir .. path.os_path_sep .. filename
     if vim.fn.filereadable(try_path) == 1 then
       logger.info("Found " .. filename .. " at " .. try_path)
       return try_path
     end
 
     -- Go up one directory
-    start_dir = M.get_directory(start_dir)
+    start_dir = path.get_directory(start_dir)
   end
 
   return nil

--- a/lua/neotest-golang/lib/find.lua
+++ b/lua/neotest-golang/lib/find.lua
@@ -8,6 +8,70 @@ local M = {}
 
 M.os_path_sep = package.config:sub(1, 1) -- "/" on Unix, "\" on Windows
 
+--- Get directory part of a path (Windows-safe replacement for fnamemodify(path, ":h")).
+--- Preserves original path separators to avoid Windows path breakage.
+--- @param path string File or directory path
+--- @return string Directory part of the path
+function M.get_directory(path)
+  if not path or path == "" then
+    return "."
+  end
+
+  -- Handle edge cases
+  if path == "/" or path == "\\" then
+    return path
+  end
+
+  -- Find the last separator (either / or \)
+  local last_sep_pos = 0
+  for i = #path, 1, -1 do
+    local char = path:sub(i, i)
+    if char == "/" or char == "\\" then
+      last_sep_pos = i
+      break
+    end
+  end
+
+  if last_sep_pos == 0 then
+    -- No separator found, it's just a filename
+    return "."
+  elseif last_sep_pos == 1 then
+    -- Root directory
+    return path:sub(1, 1)
+  else
+    -- Return everything before the last separator
+    return path:sub(1, last_sep_pos - 1)
+  end
+end
+
+--- Get filename part of a path (Windows-safe replacement for fnamemodify(path, ":t")).
+--- Preserves original path separators to avoid Windows path breakage.
+--- @param path string File or directory path
+--- @return string Filename part of the path
+function M.get_filename(path)
+  if not path or path == "" then
+    return ""
+  end
+
+  -- Find the last separator (either / or \)
+  local last_sep_pos = 0
+  for i = #path, 1, -1 do
+    local char = path:sub(i, i)
+    if char == "/" or char == "\\" then
+      last_sep_pos = i
+      break
+    end
+  end
+
+  if last_sep_pos == 0 then
+    -- No separator found, return the whole string
+    return path
+  else
+    -- Return everything after the last separator
+    return path:sub(last_sep_pos + 1)
+  end
+end
+
 --- Find a file upwards in the directory tree and return its path, if found.
 --- @param filename string Name of file to search for
 --- @param start_path string Starting directory or file path to search from
@@ -15,7 +79,7 @@ M.os_path_sep = package.config:sub(1, 1) -- "/" on Unix, "\" on Windows
 function M.file_upwards(filename, start_path)
   -- Ensure start_path is a directory
   local start_dir = vim.fn.isdirectory(start_path) == 1 and start_path
-    or vim.fn.fnamemodify(start_path, ":h")
+    or M.get_directory(start_path)
   local home_dir = vim.fn.expand("$HOME")
 
   while start_dir ~= home_dir do
@@ -28,7 +92,7 @@ function M.file_upwards(filename, start_path)
     end
 
     -- Go up one directory
-    start_dir = vim.fn.fnamemodify(start_dir, ":h")
+    start_dir = M.get_directory(start_dir)
   end
 
   return nil

--- a/lua/neotest-golang/lib/init.lua
+++ b/lua/neotest-golang/lib/init.lua
@@ -11,6 +11,7 @@ M.diagnostics = require("neotest-golang.lib.diagnostics")
 M.json = require("neotest-golang.lib.json")
 M.logging = require("neotest-golang.lib.logging")
 M.mapping = require("neotest-golang.lib.mapping")
+M.path = require("neotest-golang.lib.path")
 M.sanitize = require("neotest-golang.lib.sanitize")
 M.stream = require("neotest-golang.lib.stream")
 

--- a/lua/neotest-golang/lib/path.lua
+++ b/lua/neotest-golang/lib/path.lua
@@ -6,13 +6,13 @@ local M = {}
 -- Platform-specific path separator
 M.os_path_sep = package.config:sub(1, 1) -- "/" on Unix, "\" on Windows
 
---- Get directory part of a path (Windows-safe replacement for fnamemodify(path, ":h")).
+--- Get directory part of a path (Windows-safe replacement for vim.fn.fnamemodify(path, ":h")).
 --- Preserves original path separators to avoid Windows path breakage.
 --- @param path string File or directory path
 --- @return string Directory part of the path
 function M.get_directory(path)
   if not path or path == "" then
-    return "."
+    return "." -- Return current directory for empty/nil paths (matches vim.fn.fnamemodify behavior)
   end
 
   -- Handle edge cases
@@ -31,7 +31,7 @@ function M.get_directory(path)
   end
 
   if last_sep_pos == 0 then
-    -- No separator found, it's just a filename
+    -- No separator found, it's just a filename - return current directory (matches vim.fn.fnamemodify behavior)
     return "."
   elseif last_sep_pos == 1 then
     -- Root directory
@@ -42,7 +42,7 @@ function M.get_directory(path)
   end
 end
 
---- Get filename part of a path (Windows-safe replacement for fnamemodify(path, ":t")).
+--- Get filename part of a path (Windows-safe replacement for vim.fn.fnamemodify(path, ":t")).
 --- Preserves original path separators to avoid Windows path breakage.
 --- @param path string File or directory path
 --- @return string Filename part of the path

--- a/lua/neotest-golang/lib/path.lua
+++ b/lua/neotest-golang/lib/path.lua
@@ -1,0 +1,165 @@
+--- Centralized path utilities for cross-platform file path operations.
+--- Handles Windows drive letters, UNC paths, backslashes, and POSIX paths uniformly.
+
+local M = {}
+
+-- Platform-specific path separator
+M.os_path_sep = package.config:sub(1, 1) -- "/" on Unix, "\" on Windows
+
+--- Get directory part of a path (Windows-safe replacement for fnamemodify(path, ":h")).
+--- Preserves original path separators to avoid Windows path breakage.
+--- @param path string File or directory path
+--- @return string Directory part of the path
+function M.get_directory(path)
+  if not path or path == "" then
+    return "."
+  end
+
+  -- Handle edge cases
+  if path == "/" or path == "\\" then
+    return path
+  end
+
+  -- Find the last separator (either / or \)
+  local last_sep_pos = 0
+  for i = #path, 1, -1 do
+    local char = path:sub(i, i)
+    if char == "/" or char == "\\" then
+      last_sep_pos = i
+      break
+    end
+  end
+
+  if last_sep_pos == 0 then
+    -- No separator found, it's just a filename
+    return "."
+  elseif last_sep_pos == 1 then
+    -- Root directory
+    return path:sub(1, 1)
+  else
+    -- Return everything before the last separator
+    return path:sub(1, last_sep_pos - 1)
+  end
+end
+
+--- Get filename part of a path (Windows-safe replacement for fnamemodify(path, ":t")).
+--- Preserves original path separators to avoid Windows path breakage.
+--- @param path string File or directory path
+--- @return string Filename part of the path
+function M.get_filename(path)
+  if not path or path == "" then
+    return ""
+  end
+
+  -- Find the last separator (either / or \)
+  local last_sep_pos = 0
+  for i = #path, 1, -1 do
+    local char = path:sub(i, i)
+    if char == "/" or char == "\\" then
+      last_sep_pos = i
+      break
+    end
+  end
+
+  if last_sep_pos == 0 then
+    -- No separator found, return the whole string
+    return path
+  else
+    -- Return everything after the last separator
+    return path:sub(last_sep_pos + 1)
+  end
+end
+
+--- Platform-conditional filename extraction for optimal performance.
+--- Uses fast vim.fs.basename for POSIX-style paths, safe get_filename for Windows-style paths.
+--- @param path string File path to extract filename from
+--- @return string|nil Filename or nil if path is invalid
+function M.get_filename_fast(path)
+  if not path or type(path) ~= "string" or path == "" then
+    return nil
+  end
+
+  -- Detect Windows-style paths (drive letters, UNC paths, backslashes)
+  local is_windows_path = path:match("^[A-Za-z]:") -- Drive letter
+    or path:match("^\\\\") -- UNC path
+    or path:match("\\") -- Contains backslashes
+
+  if is_windows_path then
+    -- Windows-style path: Use our Windows-safe implementation
+    return M.get_filename(path)
+  else
+    -- POSIX-style path: Use fast built-in C function
+    return vim.fs.basename(path)
+  end
+end
+
+--- Extract file path from Neotest position ID (handles Windows drive letters correctly).
+--- @param pos_id string Position ID like "/path/to/file_test.go::TestName" or "D:\\path\\file_test.go::TestName"
+--- @return string|nil File path part before "::" or nil if not found
+function M.extract_file_path_from_pos_id(pos_id)
+  if not pos_id or type(pos_id) ~= "string" or pos_id == "" then
+    return nil
+  end
+
+  -- Find the first occurrence of "::" (which separates file path from test path)
+  local separator_pos = pos_id:find("::")
+  if separator_pos then
+    return pos_id:sub(1, separator_pos - 1)
+  end
+
+  -- If no "::" found, treat the entire string as the file path
+  return pos_id
+end
+
+--- Normalize path separators for cross-platform compatibility.
+--- Converts forward slashes to backslashes on Windows, leaves unchanged on POSIX.
+--- @param path string Path to normalize
+--- @return string Normalized path
+function M.normalize_path(path)
+  if not path or type(path) ~= "string" then
+    return ""
+  end
+
+  if vim.fn.has("win32") == 1 then
+    local normalized_path, _ = path:gsub("/", "\\")
+    return normalized_path
+  end
+  return path
+end
+
+--- Detect if a path uses Windows-style formatting.
+--- @param path string Path to analyze
+--- @return boolean True if path appears to be Windows-style
+function M.is_windows_path(path)
+  if not path or type(path) ~= "string" then
+    return false
+  end
+
+  return path:match("^[A-Za-z]:") -- Drive letter
+    or path:match("^\\\\") -- UNC path
+    or path:match("\\") -- Contains backslashes
+end
+
+--- Detect UNC (Universal Naming Convention) paths.
+--- @param path string Path to analyze
+--- @return boolean True if path is a UNC path
+function M.is_unc_path(path)
+  if not path or type(path) ~= "string" then
+    return false
+  end
+
+  return path:match("^\\\\") ~= nil
+end
+
+--- Validate Windows drive letter format.
+--- @param path string Path to validate
+--- @return boolean True if path has valid Windows drive letter
+function M.has_drive_letter(path)
+  if not path or type(path) ~= "string" then
+    return false
+  end
+
+  return path:match("^[A-Za-z]:") ~= nil
+end
+
+return M

--- a/lua/neotest-golang/results_finalize.lua
+++ b/lua/neotest-golang/results_finalize.lua
@@ -3,6 +3,7 @@
 
 local async = require("neotest.async")
 
+local find = require("neotest-golang.lib.find")
 local lib = require("neotest-golang.lib")
 local logger = require("neotest-golang.lib.logging")
 local options = require("neotest-golang.options")
@@ -132,8 +133,8 @@ function M.populate_missing_dir_results(tree, results)
   for pos_id, result in pairs(results) do
     -- Check if this is a file position (ends with .go but no "::")
     if pos_id:match("%.go$") and not pos_id:find("::") then
-      -- Extract directory path using vim.fs.dirname
-      local dir_path = vim.fs.dirname(pos_id)
+      -- Extract directory path using find.get_directory for Windows compatibility
+      local dir_path = find.get_directory(pos_id)
 
       if dir_path and dir_path ~= "." then
         if not dir_to_files[dir_path] then
@@ -154,8 +155,8 @@ function M.populate_missing_dir_results(tree, results)
   for pos_id, result in pairs(results) do
     -- Check if this is a directory position (no .go and no ::)
     if not pos_id:match("%.go$") and not pos_id:find("::") then
-      -- Extract parent directory path
-      local parent_dir = vim.fs.dirname(pos_id)
+      -- Extract parent directory path using find.get_directory for Windows compatibility
+      local parent_dir = find.get_directory(pos_id)
 
       if parent_dir and parent_dir ~= "." and parent_dir ~= pos_id then
         if not dir_to_subdirs[parent_dir] then

--- a/lua/neotest-golang/results_finalize.lua
+++ b/lua/neotest-golang/results_finalize.lua
@@ -3,8 +3,6 @@
 
 local async = require("neotest.async")
 
-local convert = require("neotest-golang.lib.convert")
-local find = require("neotest-golang.lib.find")
 local lib = require("neotest-golang.lib")
 local logger = require("neotest-golang.lib.logging")
 local options = require("neotest-golang.options")
@@ -135,7 +133,7 @@ function M.populate_missing_dir_results(tree, results)
     -- Check if this is a file position (ends with .go but no "::")
     if pos_id:match("%.go$") and not pos_id:find("::") then
       -- Extract directory path using find.get_directory for Windows compatibility
-      local dir_path = find.get_directory(pos_id)
+      local dir_path = lib.find.get_directory(pos_id)
 
       if dir_path and dir_path ~= "." then
         if not dir_to_files[dir_path] then
@@ -157,7 +155,7 @@ function M.populate_missing_dir_results(tree, results)
     -- Check if this is a directory position (no .go and no ::)
     if not pos_id:match("%.go$") and not pos_id:find("::") then
       -- Extract parent directory path using find.get_directory for Windows compatibility
-      local parent_dir = find.get_directory(pos_id)
+      local parent_dir = lib.find.get_directory(pos_id)
 
       if parent_dir and parent_dir ~= "." and parent_dir ~= pos_id then
         if not dir_to_subdirs[parent_dir] then
@@ -325,7 +323,7 @@ function M.populate_missing_file_results(tree, results)
     -- Check if this is a test position (contains "::")
     if pos_id:find("::") then
       -- Extract file path using Windows-safe method
-      local file_path = convert.extract_file_path_from_pos_id(pos_id)
+      local file_path = lib.convert.extract_file_path_from_pos_id(pos_id)
 
       if file_path and file_path:match("%.go$") then
         if not file_to_tests[file_path] then

--- a/lua/neotest-golang/results_finalize.lua
+++ b/lua/neotest-golang/results_finalize.lua
@@ -3,6 +3,7 @@
 
 local async = require("neotest.async")
 
+local convert = require("neotest-golang.lib.convert")
 local find = require("neotest-golang.lib.find")
 local lib = require("neotest-golang.lib")
 local logger = require("neotest-golang.lib.logging")
@@ -323,8 +324,8 @@ function M.populate_missing_file_results(tree, results)
   for pos_id, result in pairs(results) do
     -- Check if this is a test position (contains "::")
     if pos_id:find("::") then
-      -- Extract file path (everything before first "::")
-      local file_path = pos_id:match("^([^:]+)")
+      -- Extract file path using Windows-safe method
+      local file_path = convert.extract_file_path_from_pos_id(pos_id)
 
       if file_path and file_path:match("%.go$") then
         if not file_to_tests[file_path] then

--- a/lua/neotest-golang/results_finalize.lua
+++ b/lua/neotest-golang/results_finalize.lua
@@ -132,7 +132,6 @@ function M.populate_missing_dir_results(tree, results)
   for pos_id, result in pairs(results) do
     -- Check if this is a file position (ends with .go but no "::")
     if pos_id:match("%.go$") and not pos_id:find("::") then
-      -- Extract directory path using path.get_directory for Windows compatibility
       local dir_path = lib.path.get_directory(pos_id)
 
       if dir_path and dir_path ~= "." then
@@ -154,7 +153,6 @@ function M.populate_missing_dir_results(tree, results)
   for pos_id, result in pairs(results) do
     -- Check if this is a directory position (no .go and no ::)
     if not pos_id:match("%.go$") and not pos_id:find("::") then
-      -- Extract parent directory path using path.get_directory for Windows compatibility
       local parent_dir = lib.path.get_directory(pos_id)
 
       if parent_dir and parent_dir ~= "." and parent_dir ~= pos_id then
@@ -322,7 +320,6 @@ function M.populate_missing_file_results(tree, results)
   for pos_id, result in pairs(results) do
     -- Check if this is a test position (contains "::")
     if pos_id:find("::") then
-      -- Extract file path using Windows-safe method
       local file_path = lib.path.extract_file_path_from_pos_id(pos_id)
 
       if file_path and file_path:match("%.go$") then

--- a/lua/neotest-golang/results_finalize.lua
+++ b/lua/neotest-golang/results_finalize.lua
@@ -323,7 +323,7 @@ function M.populate_missing_file_results(tree, results)
     -- Check if this is a test position (contains "::")
     if pos_id:find("::") then
       -- Extract file path using Windows-safe method
-      local file_path = lib.convert.extract_file_path_from_pos_id(pos_id)
+      local file_path = lib.path.extract_file_path_from_pos_id(pos_id)
 
       if file_path and file_path:match("%.go$") then
         if not file_to_tests[file_path] then

--- a/lua/neotest-golang/results_finalize.lua
+++ b/lua/neotest-golang/results_finalize.lua
@@ -132,8 +132,8 @@ function M.populate_missing_dir_results(tree, results)
   for pos_id, result in pairs(results) do
     -- Check if this is a file position (ends with .go but no "::")
     if pos_id:match("%.go$") and not pos_id:find("::") then
-      -- Extract directory path using find.get_directory for Windows compatibility
-      local dir_path = lib.find.get_directory(pos_id)
+      -- Extract directory path using path.get_directory for Windows compatibility
+      local dir_path = lib.path.get_directory(pos_id)
 
       if dir_path and dir_path ~= "." then
         if not dir_to_files[dir_path] then
@@ -154,8 +154,8 @@ function M.populate_missing_dir_results(tree, results)
   for pos_id, result in pairs(results) do
     -- Check if this is a directory position (no .go and no ::)
     if not pos_id:match("%.go$") and not pos_id:find("::") then
-      -- Extract parent directory path using find.get_directory for Windows compatibility
-      local parent_dir = lib.find.get_directory(pos_id)
+      -- Extract parent directory path using path.get_directory for Windows compatibility
+      local parent_dir = lib.path.get_directory(pos_id)
 
       if parent_dir and parent_dir ~= "." and parent_dir ~= pos_id then
         if not dir_to_subdirs[parent_dir] then

--- a/lua/neotest-golang/runspec/dir.lua
+++ b/lua/neotest-golang/runspec/dir.lua
@@ -28,7 +28,7 @@ local function find_go_package_import_path(pos, golist_data)
     if
       (
         golist_item.Module.GoMod
-          == pos.path .. lib.find.os_path_sep .. "go.mod"
+          == pos.path .. lib.path.os_path_sep .. "go.mod"
         and golist_item.Name == "main"
       ) or (pos.path == golist_item.Dir and golist_item.Name == "main")
     then
@@ -65,7 +65,7 @@ local function find_go_package_import_path(pos, golist_data)
       end
     end
 
-    package_import_path = find.get_directory(shortest) .. "/..."
+    package_import_path = lib.path.get_directory(shortest) .. "/..."
     return package_import_path
   end
 

--- a/lua/neotest-golang/runspec/dir.lua
+++ b/lua/neotest-golang/runspec/dir.lua
@@ -1,6 +1,7 @@
 --- Helpers to build the command and context around running all tests of
 --- a Go package.
 
+local find = require("neotest-golang.lib.find")
 local lib = require("neotest-golang.lib")
 local logger = require("neotest-golang.lib.logging")
 local options = require("neotest-golang.options")
@@ -64,7 +65,7 @@ local function find_go_package_import_path(pos, golist_data)
       end
     end
 
-    package_import_path = vim.fn.fnamemodify(shortest, ":h") .. "/..."
+    package_import_path = find.get_directory(shortest) .. "/..."
     return package_import_path
   end
 

--- a/lua/neotest-golang/runspec/file.lua
+++ b/lua/neotest-golang/runspec/file.lua
@@ -27,8 +27,8 @@ function M.build(pos, tree, strategy)
     return nil -- NOTE: logger.error will throw an error, but the LSP doesn't see it.
   end
 
-  local go_mod_folderpath = find.get_directory(go_mod_filepath)
-  local pos_path_folderpath = find.get_directory(pos.path)
+  local go_mod_folderpath = lib.path.get_directory(go_mod_filepath)
+  local pos_path_folderpath = lib.path.get_directory(pos.path)
   local golist_data, golist_error = lib.cmd.golist_data(pos_path_folderpath)
 
   local errors = nil
@@ -41,7 +41,7 @@ function M.build(pos, tree, strategy)
 
   -- find the go package that corresponds to the pos.path
   local package_name = "./..."
-  local pos_path_filename = find.get_filename(pos.path)
+  local pos_path_filename = lib.path.get_filename(pos.path)
 
   for _, golist_item in ipairs(golist_data) do
     if golist_item.TestGoFiles ~= nil then

--- a/lua/neotest-golang/runspec/file.lua
+++ b/lua/neotest-golang/runspec/file.lua
@@ -1,6 +1,7 @@
 --- Helpers to build the command and context around running all tests of a file.
 
 local dap = require("neotest-golang.features.dap")
+local find = require("neotest-golang.lib.find")
 local lib = require("neotest-golang.lib")
 local logger = require("neotest-golang.lib.logging")
 local options = require("neotest-golang.options")
@@ -26,8 +27,8 @@ function M.build(pos, tree, strategy)
     return nil -- NOTE: logger.error will throw an error, but the LSP doesn't see it.
   end
 
-  local go_mod_folderpath = vim.fn.fnamemodify(go_mod_filepath, ":h")
-  local pos_path_folderpath = vim.fn.fnamemodify(pos.path, ":h")
+  local go_mod_folderpath = find.get_directory(go_mod_filepath)
+  local pos_path_folderpath = find.get_directory(pos.path)
   local golist_data, golist_error = lib.cmd.golist_data(pos_path_folderpath)
 
   local errors = nil
@@ -40,7 +41,7 @@ function M.build(pos, tree, strategy)
 
   -- find the go package that corresponds to the pos.path
   local package_name = "./..."
-  local pos_path_filename = vim.fn.fnamemodify(pos.path, ":t")
+  local pos_path_filename = find.get_filename(pos.path)
 
   for _, golist_item in ipairs(golist_data) do
     if golist_item.TestGoFiles ~= nil then

--- a/lua/neotest-golang/runspec/namespace.lua
+++ b/lua/neotest-golang/runspec/namespace.lua
@@ -12,7 +12,7 @@ local M = {}
 --- @return neotest.RunSpec|nil Runspec for executing tests in the namespace
 function M.build(pos, tree)
   local pos_path_folderpath =
-    string.match(pos.path, "(.+)" .. lib.find.os_path_sep)
+    string.match(pos.path, "(.+)" .. lib.path.os_path_sep)
 
   local golist_data, golist_error = lib.cmd.golist_data(pos_path_folderpath)
 

--- a/lua/neotest-golang/runspec/test.lua
+++ b/lua/neotest-golang/runspec/test.lua
@@ -1,6 +1,7 @@
 --- Helpers to build the command and context around running a single test.
 
 local dap = require("neotest-golang.features.dap")
+local find = require("neotest-golang.lib.find")
 local lib = require("neotest-golang.lib")
 local logger = require("neotest-golang.lib.logging")
 local options = require("neotest-golang.options")
@@ -13,7 +14,7 @@ local M = {}
 --- @param strategy string|nil Strategy to use (e.g., "dap" for debugging)
 --- @return neotest.RunSpec|nil Runspec for executing the test
 function M.build(pos, tree, strategy)
-  local pos_path_folderpath = vim.fn.fnamemodify(pos.path, ":h")
+  local pos_path_folderpath = find.get_directory(pos.path)
 
   local golist_data, golist_error = lib.cmd.golist_data(pos_path_folderpath)
 

--- a/lua/neotest-golang/runspec/test.lua
+++ b/lua/neotest-golang/runspec/test.lua
@@ -14,7 +14,7 @@ local M = {}
 --- @param strategy string|nil Strategy to use (e.g., "dap" for debugging)
 --- @return neotest.RunSpec|nil Runspec for executing the test
 function M.build(pos, tree, strategy)
-  local pos_path_folderpath = find.get_directory(pos.path)
+  local pos_path_folderpath = lib.path.get_directory(pos.path)
 
   local golist_data, golist_error = lib.cmd.golist_data(pos_path_folderpath)
 

--- a/spec/helpers/integration.lua
+++ b/spec/helpers/integration.lua
@@ -299,14 +299,6 @@ function M.execute_adapter_direct(position_id)
   }
 end
 
---- Normalize Windows paths for cross-platform testing
---- @param path string
---- @return string
-function M.normalize_path(path)
-  local utils = dofile(vim.uv.cwd() .. "/spec/helpers/utils.lua")
-  return utils.normalize_path(path)
-end
-
 --- Process test output manually to populate individual test results
 --- This replicates the streaming mechanism but works on completed output
 --- @param tree neotest.Tree The discovered test tree

--- a/spec/helpers/integration.lua
+++ b/spec/helpers/integration.lua
@@ -171,7 +171,7 @@ function M.execute_adapter_direct(position_id)
     end)
 
     for _, file in ipairs(dir_scan or {}) do
-      table.insert(test_files, base_path .. lib.find.os_path_sep .. file)
+      table.insert(test_files, base_path .. lib.path.os_path_sep .. file)
     end
 
     local all_nodes = {}
@@ -193,7 +193,7 @@ function M.execute_adapter_direct(position_id)
     local dir_position = {
       type = "dir",
       path = base_path,
-      name = lib.find.get_filename(base_path),
+      name = lib.path.get_filename(base_path),
       id = base_path,
       range = { 0, 0, 0, 0 },
     }

--- a/spec/helpers/integration.lua
+++ b/spec/helpers/integration.lua
@@ -82,7 +82,16 @@ function M.execute_adapter_direct(position_id)
   assert(type(position_id) == "string", "position_id must be a string")
 
   -- Parse position ID to extract components
-  local base_path, test_components = position_id:match("^([^:]+)(.*)")
+  -- Handle Windows drive letters (C:, D:, etc.) by looking for :: test separators specifically
+  local base_path, test_components
+  local double_colon_pos = position_id:find("::")
+  if double_colon_pos then
+    base_path = position_id:sub(1, double_colon_pos - 1)
+    test_components = position_id:sub(double_colon_pos)
+  else
+    base_path = position_id
+    test_components = ""
+  end
   local has_test_parts = test_components and test_components ~= ""
 
   -- Infer intent from position ID format

--- a/spec/helpers/integration.lua
+++ b/spec/helpers/integration.lua
@@ -171,7 +171,7 @@ function M.execute_adapter_direct(position_id)
     end)
 
     for _, file in ipairs(dir_scan or {}) do
-      table.insert(test_files, base_path .. "/" .. file)
+      table.insert(test_files, base_path .. lib.find.os_path_sep .. file)
     end
 
     local all_nodes = {}

--- a/spec/helpers/integration.lua
+++ b/spec/helpers/integration.lua
@@ -1,5 +1,7 @@
 --- Integration test utilities for end-to-end Go test execution
 
+local lib = require("neotest-golang.lib")
+
 ---@class AdapterExecutionResult
 ---@field tree neotest.Tree The discovered test tree
 ---@field results table<string, neotest.Result> The processed test results
@@ -191,7 +193,7 @@ function M.execute_adapter_direct(position_id)
     local dir_position = {
       type = "dir",
       path = base_path,
-      name = vim.fn.fnamemodify(base_path, ":t"),
+      name = lib.find.get_filename(base_path),
       id = base_path,
       range = { 0, 0, 0, 0 },
     }

--- a/spec/helpers/utils.lua
+++ b/spec/helpers/utils.lua
@@ -2,17 +2,6 @@
 
 local M = {}
 
---- Normalize Windows paths for cross-platform testing (forward slash → backslash)
---- @param path string
---- @return string
-function M.normalize_path(path)
-  if vim.fn.has("win32") == 1 then
-    local normalized_path, _ = path:gsub("/", "\\")
-    return normalized_path
-  end
-  return path
-end
-
 --- Normalize Windows paths to Unix style (backslash → forward slash)
 --- @param path string
 --- @return string

--- a/spec/integration/diagnostics_spec.lua
+++ b/spec/integration/diagnostics_spec.lua
@@ -1,6 +1,7 @@
 local _ = require("plenary")
 local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
+local path = require("neotest-golang.lib.path")
 
 -- Load integration helpers
 local integration_path = vim.uv.cwd() .. "/spec/helpers/integration.lua"
@@ -36,7 +37,7 @@ describe("Integration: diagnostics test", function()
             },
           },
           -- Directory-level result (created by file aggregation)
-          [find.get_directory(position_id)] = {
+          [path.get_directory(position_id)] = {
             status = "passed", -- Directory shows passed due to aggregation logic
             errors = {
               {

--- a/spec/integration/diagnostics_spec.lua
+++ b/spec/integration/diagnostics_spec.lua
@@ -1,13 +1,10 @@
 local _ = require("plenary")
-local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 local path = require("neotest-golang.lib.path")
 
 -- Load integration helpers
 local integration_path = vim.uv.cwd() .. "/spec/helpers/integration.lua"
 local integration = dofile(integration_path)
-local utils_path = vim.uv.cwd() .. "/spec/helpers/utils.lua"
-local utils = dofile(utils_path)
 
 describe("Integration: diagnostics test", function()
   it(
@@ -20,13 +17,13 @@ describe("Integration: diagnostics test", function()
 
       local position_id = vim.uv.cwd()
         .. "/tests/go/internal/diagnostics/diagnostics_test.go"
-      position_id = integration.normalize_path(position_id)
+      position_id = path.normalize_path(position_id)
 
       ---@type AdapterExecutionResult
       local want = {
         results = {
           -- Parent directory result (created by hierarchical aggregation)
-          [utils.normalize_path(vim.uv.cwd() .. "/tests/go/internal")] = {
+          [path.normalize_path(vim.uv.cwd() .. "/tests/go/internal")] = {
             status = "passed",
             errors = {
               {

--- a/spec/integration/diagnostics_spec.lua
+++ b/spec/integration/diagnostics_spec.lua
@@ -1,4 +1,5 @@
 local _ = require("plenary")
+local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 
 -- Load integration helpers
@@ -33,7 +34,7 @@ describe("Integration: diagnostics test", function()
             },
           },
           -- Directory-level result (created by file aggregation)
-          [vim.fs.dirname(position_id)] = {
+          [find.get_directory(position_id)] = {
             status = "passed", -- Directory shows passed due to aggregation logic
             errors = {
               {

--- a/spec/integration/diagnostics_spec.lua
+++ b/spec/integration/diagnostics_spec.lua
@@ -5,6 +5,8 @@ local options = require("neotest-golang.options")
 -- Load integration helpers
 local integration_path = vim.uv.cwd() .. "/spec/helpers/integration.lua"
 local integration = dofile(integration_path)
+local utils_path = vim.uv.cwd() .. "/spec/helpers/utils.lua"
+local utils = dofile(utils_path)
 
 describe("Integration: diagnostics test", function()
   it(
@@ -23,7 +25,7 @@ describe("Integration: diagnostics test", function()
       local want = {
         results = {
           -- Parent directory result (created by hierarchical aggregation)
-          [vim.uv.cwd() .. "/tests/go/internal"] = {
+          [utils.normalize_path(vim.uv.cwd() .. "/tests/go/internal")] = {
             status = "passed",
             errors = {
               {

--- a/spec/integration/multifile_spec.lua
+++ b/spec/integration/multifile_spec.lua
@@ -1,4 +1,5 @@
 local _ = require("plenary")
+local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 
 -- Load integration helpers
@@ -26,7 +27,7 @@ describe("Integration: multifile test", function()
       local want = {
         results = {
           -- Parent directory result
-          [vim.fs.dirname(pos_id_dir)] = {
+          [find.get_directory(pos_id_dir)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/multifile_spec.lua
+++ b/spec/integration/multifile_spec.lua
@@ -5,6 +5,8 @@ local options = require("neotest-golang.options")
 -- Load integration helpers
 local integration_path = vim.uv.cwd() .. "/spec/helpers/integration.lua"
 local integration = dofile(integration_path)
+local utils_path = vim.uv.cwd() .. "/spec/helpers/utils.lua"
+local utils = dofile(utils_path)
 
 describe("Integration: multifile test", function()
   it(
@@ -15,7 +17,8 @@ describe("Integration: multifile test", function()
       test_options.runner = "gotestsum"
       options.set(test_options)
 
-      local pos_id_dir = vim.uv.cwd() .. "/tests/go/internal/multifile"
+      local pos_id_dir =
+        utils.normalize_path(vim.uv.cwd() .. "/tests/go/internal/multifile")
       pos_id_dir = integration.normalize_path(pos_id_dir)
 
       local pos_id_first = pos_id_dir .. "/first_file_test.go"

--- a/spec/integration/multifile_spec.lua
+++ b/spec/integration/multifile_spec.lua
@@ -1,13 +1,10 @@
 local _ = require("plenary")
-local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 local path = require("neotest-golang.lib.path")
 
 -- Load integration helpers
 local integration_path = vim.uv.cwd() .. "/spec/helpers/integration.lua"
 local integration = dofile(integration_path)
-local utils_path = vim.uv.cwd() .. "/spec/helpers/utils.lua"
-local utils = dofile(utils_path)
 
 describe("Integration: multifile test", function()
   it(
@@ -19,13 +16,12 @@ describe("Integration: multifile test", function()
       options.set(test_options)
 
       local pos_id_dir =
-        utils.normalize_path(vim.uv.cwd() .. "/tests/go/internal/multifile")
-      pos_id_dir = integration.normalize_path(pos_id_dir)
+        path.normalize_path(vim.uv.cwd() .. "/tests/go/internal/multifile")
 
       local pos_id_first = pos_id_dir .. "/first_file_test.go"
       local pos_id_second = pos_id_dir .. "/second_file_test.go"
-      pos_id_first = integration.normalize_path(pos_id_first)
-      pos_id_second = integration.normalize_path(pos_id_second)
+      pos_id_first = path.normalize_path(pos_id_first)
+      pos_id_second = path.normalize_path(pos_id_second)
 
       ---@type AdapterExecutionResult
       local want = {

--- a/spec/integration/multifile_spec.lua
+++ b/spec/integration/multifile_spec.lua
@@ -1,6 +1,7 @@
 local _ = require("plenary")
 local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
+local path = require("neotest-golang.lib.path")
 
 -- Load integration helpers
 local integration_path = vim.uv.cwd() .. "/spec/helpers/integration.lua"
@@ -30,7 +31,7 @@ describe("Integration: multifile test", function()
       local want = {
         results = {
           -- Parent directory result
-          [find.get_directory(pos_id_dir)] = {
+          [path.get_directory(pos_id_dir)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/nested_spec.lua
+++ b/spec/integration/nested_spec.lua
@@ -1,13 +1,10 @@
 local _ = require("plenary")
-local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 local path = require("neotest-golang.lib.path")
 
 -- Load integration helpers
 local integration_path = vim.uv.cwd() .. "/spec/helpers/integration.lua"
 local integration = dofile(integration_path)
-local utils_path = vim.uv.cwd() .. "/spec/helpers/utils.lua"
-local utils = dofile(utils_path)
 
 describe("Integration: nested subpackage2 test", function()
   it(
@@ -18,10 +15,8 @@ describe("Integration: nested subpackage2 test", function()
       test_options.runner = "gotestsum"
       options.set(test_options)
 
-      -- Test the entire nested directory structure
       local position_id =
-        utils.normalize_path(vim.uv.cwd() .. "/tests/go/internal/nested")
-      position_id = integration.normalize_path(position_id)
+        path.normalize_path(vim.uv.cwd() .. "/tests/go/internal/nested")
 
       -- Calculate nested directory position ID (same as position_id in this case)
       local nested_dir_id = position_id
@@ -103,13 +98,13 @@ describe("Integration: nested subpackage2 test", function()
 
       local position_id = vim.uv.cwd()
         .. "/tests/go/internal/nested/subpackage2/subpackage2_test.go"
-      position_id = integration.normalize_path(position_id)
+      position_id = path.normalize_path(position_id)
 
       ---@type AdapterExecutionResult
       local want = {
         results = {
           -- Parent directory result (created by hierarchical aggregation)
-          [utils.normalize_path(vim.uv.cwd() .. "/tests/go/internal/nested")] = {
+          [path.normalize_path(vim.uv.cwd() .. "/tests/go/internal/nested")] = {
             status = "passed",
             errors = {},
           },
@@ -190,13 +185,13 @@ describe("Integration: nested subpackage2 test", function()
 
       local position_id = vim.uv.cwd()
         .. "/tests/go/internal/nested/subpackage2/subpackage3/subpackage3_test.go"
-      position_id = integration.normalize_path(position_id)
+      position_id = path.normalize_path(position_id)
 
       ---@type AdapterExecutionResult
       local want = {
         results = {
           -- Parent directory result (created by hierarchical aggregation)
-          [utils.normalize_path(
+          [path.normalize_path(
             vim.uv.cwd() .. "/tests/go/internal/nested/subpackage2"
           )] = {
             status = "passed",

--- a/spec/integration/nested_spec.lua
+++ b/spec/integration/nested_spec.lua
@@ -1,4 +1,5 @@
 local _ = require("plenary")
+local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 
 -- Load integration helpers
@@ -109,7 +110,7 @@ describe("Integration: nested subpackage2 test", function()
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [vim.fs.dirname(position_id)] = {
+          [find.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },
@@ -196,7 +197,7 @@ describe("Integration: nested subpackage2 test", function()
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [vim.fs.dirname(position_id)] = {
+          [find.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/nested_spec.lua
+++ b/spec/integration/nested_spec.lua
@@ -5,6 +5,8 @@ local options = require("neotest-golang.options")
 -- Load integration helpers
 local integration_path = vim.uv.cwd() .. "/spec/helpers/integration.lua"
 local integration = dofile(integration_path)
+local utils_path = vim.uv.cwd() .. "/spec/helpers/utils.lua"
+local utils = dofile(utils_path)
 
 describe("Integration: nested subpackage2 test", function()
   it(
@@ -16,7 +18,8 @@ describe("Integration: nested subpackage2 test", function()
       options.set(test_options)
 
       -- Test the entire nested directory structure
-      local position_id = vim.uv.cwd() .. "/tests/go/internal/nested"
+      local position_id =
+        utils.normalize_path(vim.uv.cwd() .. "/tests/go/internal/nested")
       position_id = integration.normalize_path(position_id)
 
       -- Calculate nested directory position ID (same as position_id in this case)
@@ -105,7 +108,7 @@ describe("Integration: nested subpackage2 test", function()
       local want = {
         results = {
           -- Parent directory result (created by hierarchical aggregation)
-          [vim.uv.cwd() .. "/tests/go/internal/nested"] = {
+          [utils.normalize_path(vim.uv.cwd() .. "/tests/go/internal/nested")] = {
             status = "passed",
             errors = {},
           },
@@ -192,7 +195,9 @@ describe("Integration: nested subpackage2 test", function()
       local want = {
         results = {
           -- Parent directory result (created by hierarchical aggregation)
-          [vim.uv.cwd() .. "/tests/go/internal/nested/subpackage2"] = {
+          [utils.normalize_path(
+            vim.uv.cwd() .. "/tests/go/internal/nested/subpackage2"
+          )] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/nested_spec.lua
+++ b/spec/integration/nested_spec.lua
@@ -1,6 +1,7 @@
 local _ = require("plenary")
 local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
+local path = require("neotest-golang.lib.path")
 
 -- Load integration helpers
 local integration_path = vim.uv.cwd() .. "/spec/helpers/integration.lua"
@@ -113,7 +114,7 @@ describe("Integration: nested subpackage2 test", function()
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [find.get_directory(position_id)] = {
+          [path.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },
@@ -202,7 +203,7 @@ describe("Integration: nested subpackage2 test", function()
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [find.get_directory(position_id)] = {
+          [path.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/packaging_blackbox_spec.lua
+++ b/spec/integration/packaging_blackbox_spec.lua
@@ -1,6 +1,7 @@
 local _ = require("plenary")
 local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
+local path = require("neotest-golang.lib.path")
 
 -- Load integration helpers
 local integration_path = vim.uv.cwd() .. "/spec/helpers/integration.lua"
@@ -28,12 +29,12 @@ describe("Integration: packaging blackbox test", function()
       local want = {
         results = {
           -- Parent directory result
-          [find.get_directory(find.get_directory(position_id))] = {
+          [path.get_directory(path.get_directory(position_id))] = {
             status = "passed",
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [find.get_directory(position_id)] = {
+          [path.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/packaging_blackbox_spec.lua
+++ b/spec/integration/packaging_blackbox_spec.lua
@@ -1,4 +1,5 @@
 local _ = require("plenary")
+local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 
 -- Load integration helpers
@@ -27,12 +28,12 @@ describe("Integration: packaging blackbox test", function()
       local want = {
         results = {
           -- Parent directory result
-          [vim.fs.dirname(vim.fs.dirname(position_id))] = {
+          [find.get_directory(find.get_directory(position_id))] = {
             status = "passed",
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [vim.fs.dirname(position_id)] = {
+          [find.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/packaging_blackbox_spec.lua
+++ b/spec/integration/packaging_blackbox_spec.lua
@@ -1,5 +1,4 @@
 local _ = require("plenary")
-local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 local path = require("neotest-golang.lib.path")
 
@@ -18,7 +17,7 @@ describe("Integration: packaging blackbox test", function()
 
       local position_id = vim.uv.cwd()
         .. "/tests/go/internal/packaging/blackbox_test.go"
-      position_id = integration.normalize_path(position_id)
+      position_id = path.normalize_path(position_id)
 
       -- ===== ACT =====
       ---@type AdapterExecutionResult

--- a/spec/integration/packaging_whitebox_spec.lua
+++ b/spec/integration/packaging_whitebox_spec.lua
@@ -1,4 +1,5 @@
 local _ = require("plenary")
+local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 
 -- Load integration helpers
@@ -27,12 +28,12 @@ describe("Integration: packaging whitebox test", function()
       local want = {
         results = {
           -- Parent directory result
-          [vim.fs.dirname(vim.fs.dirname(position_id))] = {
+          [find.get_directory(find.get_directory(position_id))] = {
             status = "passed",
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [vim.fs.dirname(position_id)] = {
+          [find.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/packaging_whitebox_spec.lua
+++ b/spec/integration/packaging_whitebox_spec.lua
@@ -1,6 +1,7 @@
 local _ = require("plenary")
 local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
+local path = require("neotest-golang.lib.path")
 
 -- Load integration helpers
 local integration_path = vim.uv.cwd() .. "/spec/helpers/integration.lua"
@@ -28,12 +29,12 @@ describe("Integration: packaging whitebox test", function()
       local want = {
         results = {
           -- Parent directory result
-          [find.get_directory(find.get_directory(position_id))] = {
+          [path.get_directory(path.get_directory(position_id))] = {
             status = "passed",
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [find.get_directory(position_id)] = {
+          [path.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/packaging_whitebox_spec.lua
+++ b/spec/integration/packaging_whitebox_spec.lua
@@ -1,5 +1,4 @@
 local _ = require("plenary")
-local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 local path = require("neotest-golang.lib.path")
 
@@ -18,7 +17,7 @@ describe("Integration: packaging whitebox test", function()
 
       local position_id = vim.uv.cwd()
         .. "/tests/go/internal/packaging/whitebox_test.go"
-      position_id = integration.normalize_path(position_id)
+      position_id = path.normalize_path(position_id)
 
       -- ===== ACT =====
       ---@type AdapterExecutionResult

--- a/spec/integration/positions_spec.lua
+++ b/spec/integration/positions_spec.lua
@@ -1,4 +1,5 @@
 local _ = require("plenary")
+local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 
 -- Load integration helpers
@@ -32,7 +33,7 @@ describe("Integration: positions test", function()
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [vim.fs.dirname(position_id)] = {
+          [find.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/positions_spec.lua
+++ b/spec/integration/positions_spec.lua
@@ -1,5 +1,4 @@
 local _ = require("plenary")
-local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 local path = require("neotest-golang.lib.path")
 
@@ -18,7 +17,7 @@ describe("Integration: positions test", function()
 
       local position_id = vim.uv.cwd()
         .. "/tests/go/internal/positions/positions_test.go"
-      position_id = integration.normalize_path(position_id)
+      position_id = path.normalize_path(position_id)
 
       -- ===== ACT =====
       ---@type AdapterExecutionResult

--- a/spec/integration/positions_spec.lua
+++ b/spec/integration/positions_spec.lua
@@ -28,7 +28,7 @@ describe("Integration: positions test", function()
       local want = {
         results = {
           -- Parent directory result (created by hierarchical aggregation)
-          [vim.uv.cwd() .. "/tests/go/internal"] = {
+          [vim.uv.cwd() .. find.os_path_sep .. "tests" .. find.os_path_sep .. "go" .. find.os_path_sep .. "internal"] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/positions_spec.lua
+++ b/spec/integration/positions_spec.lua
@@ -1,6 +1,7 @@
 local _ = require("plenary")
 local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
+local path = require("neotest-golang.lib.path")
 
 -- Load integration helpers
 local integration_path = vim.uv.cwd() .. "/spec/helpers/integration.lua"
@@ -28,12 +29,12 @@ describe("Integration: positions test", function()
       local want = {
         results = {
           -- Parent directory result (created by hierarchical aggregation)
-          [vim.uv.cwd() .. find.os_path_sep .. "tests" .. find.os_path_sep .. "go" .. find.os_path_sep .. "internal"] = {
+          [vim.uv.cwd() .. path.os_path_sep .. "tests" .. path.os_path_sep .. "go" .. path.os_path_sep .. "internal"] = {
             status = "passed",
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [find.get_directory(position_id)] = {
+          [path.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/precision_spec.lua
+++ b/spec/integration/precision_spec.lua
@@ -1,4 +1,5 @@
 local _ = require("plenary")
+local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 
 -- Load integration helpers
@@ -28,12 +29,12 @@ describe("Integration: treesitter precision test", function()
       local want = {
         results = {
           -- Parent directory result
-          [vim.fs.dirname(vim.fs.dirname(position_id))] = {
+          [find.get_directory(find.get_directory(position_id))] = {
             status = "passed",
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [vim.fs.dirname(position_id)] = {
+          [find.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/precision_spec.lua
+++ b/spec/integration/precision_spec.lua
@@ -1,6 +1,7 @@
 local _ = require("plenary")
 local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
+local path = require("neotest-golang.lib.path")
 
 -- Load integration helpers
 local integration_path = vim.uv.cwd() .. "/spec/helpers/integration.lua"
@@ -29,12 +30,12 @@ describe("Integration: treesitter precision test", function()
       local want = {
         results = {
           -- Parent directory result
-          [find.get_directory(find.get_directory(position_id))] = {
+          [path.get_directory(path.get_directory(position_id))] = {
             status = "passed",
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [find.get_directory(position_id)] = {
+          [path.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/precision_spec.lua
+++ b/spec/integration/precision_spec.lua
@@ -1,5 +1,4 @@
 local _ = require("plenary")
-local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 local path = require("neotest-golang.lib.path")
 
@@ -18,7 +17,7 @@ describe("Integration: treesitter precision test", function()
 
       local position_id = vim.uv.cwd()
         .. "/tests/go/internal/precision/treesitter_precision_test.go"
-      position_id = integration.normalize_path(position_id)
+      position_id = path.normalize_path(position_id)
 
       -- ===== ACT =====
       ---@type AdapterExecutionResult

--- a/spec/integration/singletest_spec.lua
+++ b/spec/integration/singletest_spec.lua
@@ -16,9 +16,17 @@ describe("Integration: individual test example", function()
       options.set(test_options)
 
       local position_id_file = vim.uv.cwd()
-        .. "/tests/go/internal/singletest/singletest_test.go"
-      local position_id_test = integration.normalize_path(position_id_file)
-        .. "::TestOne"
+        .. find.os_path_sep
+        .. "tests"
+        .. find.os_path_sep
+        .. "go"
+        .. find.os_path_sep
+        .. "internal"
+        .. find.os_path_sep
+        .. "singletest"
+        .. find.os_path_sep
+        .. "singletest_test.go"
+      local position_id_test = position_id_file .. "::TestOne"
 
       -- Expected complete adapter execution result - only TestOne should run
       ---@type AdapterExecutionResult

--- a/spec/integration/singletest_spec.lua
+++ b/spec/integration/singletest_spec.lua
@@ -1,5 +1,4 @@
 local _ = require("plenary")
-local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 local path = require("neotest-golang.lib.path")
 
@@ -44,7 +43,7 @@ describe("Integration: individual test example", function()
             errors = {},
           },
           -- File-level result
-          [integration.normalize_path(position_id_file)] = {
+          [path.normalize_path(position_id_file)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/singletest_spec.lua
+++ b/spec/integration/singletest_spec.lua
@@ -1,6 +1,7 @@
 local _ = require("plenary")
 local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
+local path = require("neotest-golang.lib.path")
 
 -- Load integration helpers
 local integration_path = vim.uv.cwd() .. "/spec/helpers/integration.lua"
@@ -16,15 +17,15 @@ describe("Integration: individual test example", function()
       options.set(test_options)
 
       local position_id_file = vim.uv.cwd()
-        .. find.os_path_sep
+        .. path.os_path_sep
         .. "tests"
-        .. find.os_path_sep
+        .. path.os_path_sep
         .. "go"
-        .. find.os_path_sep
+        .. path.os_path_sep
         .. "internal"
-        .. find.os_path_sep
+        .. path.os_path_sep
         .. "singletest"
-        .. find.os_path_sep
+        .. path.os_path_sep
         .. "singletest_test.go"
       local position_id_test = position_id_file .. "::TestOne"
 
@@ -33,12 +34,12 @@ describe("Integration: individual test example", function()
       local want = {
         results = {
           -- Parent directory result
-          [find.get_directory(find.get_directory(position_id_file))] = {
+          [path.get_directory(path.get_directory(position_id_file))] = {
             status = "passed",
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [find.get_directory(position_id_file)] = {
+          [path.get_directory(position_id_file)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/singletest_spec.lua
+++ b/spec/integration/singletest_spec.lua
@@ -1,4 +1,5 @@
 local _ = require("plenary")
+local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 
 -- Load integration helpers
@@ -24,12 +25,12 @@ describe("Integration: individual test example", function()
       local want = {
         results = {
           -- Parent directory result
-          [vim.fs.dirname(vim.fs.dirname(position_id_file))] = {
+          [find.get_directory(find.get_directory(position_id_file))] = {
             status = "passed",
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [vim.fs.dirname(position_id_file)] = {
+          [find.get_directory(position_id_file)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/specialchars_spec.lua
+++ b/spec/integration/specialchars_spec.lua
@@ -1,6 +1,7 @@
 local _ = require("plenary")
 local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
+local path = require("neotest-golang.lib.path")
 
 -- Load integration helpers
 local integration_path = vim.uv.cwd() .. "/spec/helpers/integration.lua"
@@ -28,12 +29,12 @@ describe("Integration: special characters test", function()
       local want = {
         results = {
           -- Parent directory result
-          [find.get_directory(find.get_directory(position_id))] = {
+          [path.get_directory(path.get_directory(position_id))] = {
             status = "passed",
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [find.get_directory(position_id)] = {
+          [path.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/specialchars_spec.lua
+++ b/spec/integration/specialchars_spec.lua
@@ -1,5 +1,4 @@
 local _ = require("plenary")
-local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 local path = require("neotest-golang.lib.path")
 
@@ -18,7 +17,7 @@ describe("Integration: special characters test", function()
 
       local position_id = vim.uv.cwd()
         .. "/tests/go/internal/specialchars/special_characters_test.go"
-      position_id = integration.normalize_path(position_id)
+      position_id = path.normalize_path(position_id)
 
       -- ===== ACT =====
       ---@type AdapterExecutionResult

--- a/spec/integration/specialchars_spec.lua
+++ b/spec/integration/specialchars_spec.lua
@@ -1,4 +1,5 @@
 local _ = require("plenary")
+local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 
 -- Load integration helpers
@@ -27,12 +28,12 @@ describe("Integration: special characters test", function()
       local want = {
         results = {
           -- Parent directory result
-          [vim.fs.dirname(vim.fs.dirname(position_id))] = {
+          [find.get_directory(find.get_directory(position_id))] = {
             status = "passed",
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [vim.fs.dirname(position_id)] = {
+          [find.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/testifysuites_othersuite_spec.lua
+++ b/spec/integration/testifysuites_othersuite_spec.lua
@@ -1,6 +1,7 @@
 local _ = require("plenary")
 local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
+local path = require("neotest-golang.lib.path")
 
 -- Load integration helpers
 local integration_path = vim.uv.cwd() .. "/spec/helpers/integration.lua"
@@ -29,12 +30,12 @@ describe("Integration: testify othersuite test", function()
       local want = {
         results = {
           -- Parent directory result
-          [find.get_directory(find.get_directory(position_id))] = {
+          [path.get_directory(path.get_directory(position_id))] = {
             status = "passed",
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [find.get_directory(position_id)] = {
+          [path.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/testifysuites_othersuite_spec.lua
+++ b/spec/integration/testifysuites_othersuite_spec.lua
@@ -1,5 +1,4 @@
 local _ = require("plenary")
-local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 local path = require("neotest-golang.lib.path")
 
@@ -19,7 +18,7 @@ describe("Integration: testify othersuite test", function()
 
       local position_id = vim.uv.cwd()
         .. "/tests/go/internal/testifysuites/othersuite_test.go"
-      position_id = integration.normalize_path(position_id)
+      position_id = path.normalize_path(position_id)
 
       -- ===== ACT =====
       ---@type AdapterExecutionResult

--- a/spec/integration/testifysuites_othersuite_spec.lua
+++ b/spec/integration/testifysuites_othersuite_spec.lua
@@ -1,4 +1,5 @@
 local _ = require("plenary")
+local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 
 -- Load integration helpers
@@ -28,12 +29,12 @@ describe("Integration: testify othersuite test", function()
       local want = {
         results = {
           -- Parent directory result
-          [vim.fs.dirname(vim.fs.dirname(position_id))] = {
+          [find.get_directory(find.get_directory(position_id))] = {
             status = "passed",
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [vim.fs.dirname(position_id)] = {
+          [find.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/testifysuites_positions_spec.lua
+++ b/spec/integration/testifysuites_positions_spec.lua
@@ -1,5 +1,4 @@
 local _ = require("plenary")
-local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 local path = require("neotest-golang.lib.path")
 
@@ -20,7 +19,7 @@ describe("Integration: testify suites positions test", function()
 
       local position_id = vim.uv.cwd()
         .. "/tests/go/internal/testifysuites/positions_test.go"
-      position_id = integration.normalize_path(position_id)
+      position_id = path.normalize_path(position_id)
 
       -- ===== ACT =====
       ---@type AdapterExecutionResult

--- a/spec/integration/testifysuites_positions_spec.lua
+++ b/spec/integration/testifysuites_positions_spec.lua
@@ -1,6 +1,7 @@
 local _ = require("plenary")
 local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
+local path = require("neotest-golang.lib.path")
 
 -- Load integration helpers
 local integration_path = vim.uv.cwd() .. "/spec/helpers/integration.lua"
@@ -30,12 +31,12 @@ describe("Integration: testify suites positions test", function()
       local want = {
         results = {
           -- Parent directory result
-          [find.get_directory(find.get_directory(position_id))] = {
+          [path.get_directory(path.get_directory(position_id))] = {
             status = "passed",
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [find.get_directory(position_id)] = {
+          [path.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/testifysuites_positions_spec.lua
+++ b/spec/integration/testifysuites_positions_spec.lua
@@ -1,4 +1,5 @@
 local _ = require("plenary")
+local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 
 -- Load integration helpers
@@ -29,12 +30,12 @@ describe("Integration: testify suites positions test", function()
       local want = {
         results = {
           -- Parent directory result
-          [vim.fs.dirname(vim.fs.dirname(position_id))] = {
+          [find.get_directory(find.get_directory(position_id))] = {
             status = "passed",
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [vim.fs.dirname(position_id)] = {
+          [find.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/teststates_spec.lua
+++ b/spec/integration/teststates_spec.lua
@@ -1,4 +1,5 @@
 local _ = require("plenary")
+local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 
 -- Load integration helpers
@@ -32,7 +33,7 @@ describe("Integration: test states", function()
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [vim.fs.dirname(position_id)] = {
+          [find.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/teststates_spec.lua
+++ b/spec/integration/teststates_spec.lua
@@ -28,7 +28,7 @@ describe("Integration: test states", function()
       local want = {
         results = {
           -- Parent directory result (created by hierarchical aggregation)
-          [vim.uv.cwd() .. "/tests/go/internal"] = {
+          [vim.uv.cwd() .. find.os_path_sep .. "tests" .. find.os_path_sep .. "go" .. find.os_path_sep .. "internal"] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/teststates_spec.lua
+++ b/spec/integration/teststates_spec.lua
@@ -1,6 +1,7 @@
 local _ = require("plenary")
 local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
+local path = require("neotest-golang.lib.path")
 
 -- Load integration helpers
 local integration_path = vim.uv.cwd() .. "/spec/helpers/integration.lua"
@@ -28,12 +29,12 @@ describe("Integration: test states", function()
       local want = {
         results = {
           -- Parent directory result (created by hierarchical aggregation)
-          [vim.uv.cwd() .. find.os_path_sep .. "tests" .. find.os_path_sep .. "go" .. find.os_path_sep .. "internal"] = {
+          [vim.uv.cwd() .. path.os_path_sep .. "tests" .. path.os_path_sep .. "go" .. path.os_path_sep .. "internal"] = {
             status = "passed",
             errors = {},
           },
           -- Directory-level result (created by file aggregation)
-          [find.get_directory(position_id)] = {
+          [path.get_directory(position_id)] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/teststates_spec.lua
+++ b/spec/integration/teststates_spec.lua
@@ -1,5 +1,4 @@
 local _ = require("plenary")
-local find = require("neotest-golang.lib.find")
 local options = require("neotest-golang.options")
 local path = require("neotest-golang.lib.path")
 
@@ -18,7 +17,7 @@ describe("Integration: test states", function()
 
       local position_id = vim.uv.cwd()
         .. "/tests/go/internal/teststates/teststates_test.go"
-      position_id = integration.normalize_path(position_id)
+      position_id = path.normalize_path(position_id)
 
       -- ===== ACT =====
       ---@type AdapterExecutionResult

--- a/spec/unit/convert_spec.lua
+++ b/spec/unit/convert_spec.lua
@@ -419,7 +419,7 @@ describe("Platform-conditional path utilities", function()
         return original_basename(path)
       end
 
-      local result = lib.convert.get_filename_fast("/path/to/file_test.go")
+      local result = lib.path.get_filename_fast("/path/to/file_test.go")
 
       -- Verify the fast path was used
       assert.is_true(basename_called)
@@ -441,8 +441,7 @@ describe("Platform-conditional path utilities", function()
       end
 
       -- Test with Windows path
-      local result =
-        lib.convert.get_filename_fast("D:\\\\project\\\\file_test.go")
+      local result = lib.path.get_filename_fast("D:\\\\project\\\\file_test.go")
 
       -- Should work correctly with Windows paths
       assert.equals("file_test.go", result)
@@ -462,7 +461,7 @@ describe("Platform-conditional path utilities", function()
       end
 
       local result =
-        lib.convert.get_filename_fast("\\\\\\\\server\\\\share\\\\file_test.go")
+        lib.path.get_filename_fast("\\\\\\\\server\\\\share\\\\file_test.go")
 
       assert.equals("file_test.go", result)
 
@@ -479,11 +478,11 @@ describe("Platform-conditional path utilities", function()
 
         -- Test that function works correctly with POSIX-style paths
         local posix_result =
-          lib.convert.get_filename_fast("/unix/path/file_test.go")
+          lib.path.get_filename_fast("/unix/path/file_test.go")
         assert.equals("file_test.go", posix_result)
 
         -- Test that function exists and is callable (Windows path testing done in Windows-specific test)
-        assert.is_function(lib.convert.get_filename_fast)
+        assert.is_function(lib.path.get_filename_fast)
       end
     )
   end)

--- a/spec/unit/diagnostics_spec.lua
+++ b/spec/unit/diagnostics_spec.lua
@@ -380,4 +380,138 @@ describe("process_diagnostics", function()
       assert.equals("Mixed separator test", errs[1].message)
     end)
   end)
+
+  describe("Performance: filename caching", function()
+    it(
+      "caches filename extraction to avoid repeated expensive operations",
+      function()
+        local test_entry = {
+          metadata = {
+            position_id = "/abs/path/my_test.go::TestSomething",
+            output_parts = {
+              "my_test.go:10: First diagnostic",
+              "my_test.go:15: Second diagnostic",
+              "my_test.go:20: Third diagnostic",
+            },
+          },
+        }
+
+        -- Process diagnostics - should cache filename on first extraction
+        local errs = lib.diagnostics.process_diagnostics(test_entry)
+
+        -- Verify caching worked
+        assert.equals("my_test.go", test_entry.metadata._cached_filename)
+        assert.equals(3, #errs)
+
+        -- All diagnostics should be included since they match cached filename
+        assert.equals("First diagnostic", errs[1].message)
+        assert.equals("Second diagnostic", errs[2].message)
+        assert.equals("Third diagnostic", errs[3].message)
+      end
+    )
+
+    it("handles Windows drive letter paths in caching", function()
+      local test_entry = {
+        metadata = {
+          position_id = "D:\\\\project\\\\windows_test.go::TestWindows",
+          output_parts = {
+            "windows_test.go:5: Windows diagnostic one",
+            "windows_test.go:10: Windows diagnostic two",
+          },
+        },
+      }
+
+      local errs = lib.diagnostics.process_diagnostics(test_entry)
+
+      -- Verify Windows filename cached correctly
+      assert.equals("windows_test.go", test_entry.metadata._cached_filename)
+      assert.equals(2, #errs)
+      assert.equals("Windows diagnostic one", errs[1].message)
+      assert.equals("Windows diagnostic two", errs[2].message)
+    end)
+
+    it("handles Windows UNC paths in caching", function()
+      local test_entry = {
+        metadata = {
+          position_id = "\\\\\\\\server\\\\share\\\\project\\\\unc_test.go::TestUNC",
+          output_parts = {
+            "unc_test.go:15: UNC diagnostic",
+          },
+        },
+      }
+
+      local errs = lib.diagnostics.process_diagnostics(test_entry)
+
+      -- Verify UNC filename cached correctly
+      assert.equals("unc_test.go", test_entry.metadata._cached_filename)
+      assert.equals(1, #errs)
+      assert.equals("UNC diagnostic", errs[1].message)
+    end)
+
+    it("filters out diagnostics when cached filename doesn't match", function()
+      local test_entry = {
+        metadata = {
+          position_id = "/abs/path/target_test.go::TestTarget",
+          output_parts = {
+            "target_test.go:5: Should be included",
+            "other_test.go:10: Should be filtered out",
+            "target_test.go:15: Should be included",
+          },
+        },
+      }
+
+      local errs = lib.diagnostics.process_diagnostics(test_entry)
+
+      -- Verify correct filename cached and filtering worked
+      assert.equals("target_test.go", test_entry.metadata._cached_filename)
+      assert.equals(2, #errs)
+      assert.equals("Should be included", errs[1].message)
+      assert.equals("Should be included", errs[2].message)
+    end)
+
+    it("handles position_id without file extension gracefully", function()
+      local test_entry = {
+        metadata = {
+          position_id = "github.com/pkg/module::TestSomething",
+          output_parts = {
+            "go:5: Some diagnostic",
+            "module_test.go:10: Another diagnostic",
+          },
+        },
+      }
+
+      local errs = lib.diagnostics.process_diagnostics(test_entry)
+
+      -- When no filename can be extracted, should include all diagnostics
+      assert.is_nil(test_entry.metadata._cached_filename)
+      assert.equals(2, #errs)
+    end)
+
+    it("reuses cached filename across multiple calls", function()
+      local test_entry = {
+        metadata = {
+          position_id = "/abs/path/reuse_test.go::TestReuse",
+          output_parts = {
+            "reuse_test.go:5: First call",
+          },
+        },
+      }
+
+      -- First call should cache
+      local errs1 = lib.diagnostics.process_diagnostics(test_entry)
+      assert.equals("reuse_test.go", test_entry.metadata._cached_filename)
+      assert.equals(1, #errs1)
+
+      -- Add more output and call again
+      test_entry.metadata.output_parts = {
+        "reuse_test.go:10: Second call",
+      }
+
+      -- Second call should reuse cache
+      local errs2 = lib.diagnostics.process_diagnostics(test_entry)
+      assert.equals("reuse_test.go", test_entry.metadata._cached_filename)
+      assert.equals(1, #errs2)
+      assert.equals("Second call", errs2[1].message)
+    end)
+  end)
 end)

--- a/spec/unit/diagnostics_spec.lua
+++ b/spec/unit/diagnostics_spec.lua
@@ -57,6 +57,99 @@ describe("parse_diagnostic_line", function()
       end
     end
   end)
+
+  describe("Windows path handling", function()
+    it("parses Windows paths with drive letters and backslashes", function()
+      local cases = {
+        {
+          line = "D:\\\\project\\\\test.go:123: debug message",
+          expected = {
+            filename = "D:\\\\project\\\\test.go",
+            line_number = 123,
+            message = "debug message",
+            severity = vim.diagnostic.severity.HINT,
+          },
+        },
+        {
+          line = "C:\\\\Users\\\\test\\\\project\\\\my_test.go:456: panic: error occurred",
+          expected = {
+            filename = "C:\\\\Users\\\\test\\\\project\\\\my_test.go",
+            line_number = 456,
+            message = "panic: error occurred",
+            severity = vim.diagnostic.severity.ERROR,
+          },
+        },
+        {
+          line = "  C:\\\\temp\\\\file_test.go:789: indented Windows message",
+          expected = {
+            filename = "C:\\\\temp\\\\file_test.go",
+            line_number = 789,
+            message = "indented Windows message",
+            severity = vim.diagnostic.severity.HINT,
+          },
+        },
+      }
+
+      for _, case in ipairs(cases) do
+        local res = lib.diagnostics.parse_diagnostic_line(case.line)
+        if case.expected then
+          assert.is_not_nil(res, "Should parse: " .. case.line)
+          assert.equals(case.expected.filename, res.filename)
+          assert.equals(case.expected.line_number, res.line_number)
+          assert.equals(case.expected.message, res.message)
+          assert.equals(case.expected.severity, res.severity)
+        else
+          assert.is_nil(res, "Should not parse: " .. case.line)
+        end
+      end
+    end)
+
+    it("parses Windows UNC paths", function()
+      local cases = {
+        {
+          line = "\\\\\\\\server\\\\share\\\\project\\\\test.go:100: UNC path message",
+          expected = {
+            filename = "\\\\\\\\server\\\\share\\\\project\\\\test.go",
+            line_number = 100,
+            message = "UNC path message",
+            severity = vim.diagnostic.severity.HINT,
+          },
+        },
+      }
+
+      for _, case in ipairs(cases) do
+        local res = lib.diagnostics.parse_diagnostic_line(case.line)
+        assert.is_not_nil(res, "Should parse: " .. case.line)
+        assert.equals(case.expected.filename, res.filename)
+        assert.equals(case.expected.line_number, res.line_number)
+        assert.equals(case.expected.message, res.message)
+        assert.equals(case.expected.severity, res.severity)
+      end
+    end)
+
+    it("parses Windows paths with mixed separators", function()
+      local cases = {
+        {
+          line = "C:\\\\Users\\\\test/project\\\\mixed_test.go:200: mixed separator message",
+          expected = {
+            filename = "C:\\\\Users\\\\test/project\\\\mixed_test.go",
+            line_number = 200,
+            message = "mixed separator message",
+            severity = vim.diagnostic.severity.HINT,
+          },
+        },
+      }
+
+      for _, case in ipairs(cases) do
+        local res = lib.diagnostics.parse_diagnostic_line(case.line)
+        assert.is_not_nil(res, "Should parse: " .. case.line)
+        assert.equals(case.expected.filename, res.filename)
+        assert.equals(case.expected.line_number, res.line_number)
+        assert.equals(case.expected.message, res.message)
+        assert.equals(case.expected.severity, res.severity)
+      end
+    end)
+  end)
 end)
 
 describe("is_hint_message", function()
@@ -215,4 +308,76 @@ describe("process_diagnostics", function()
       assert.is_true(vim.tbl_contains(one_index_lines, 3))
     end
   )
+
+  describe("Windows path handling in position_id", function()
+    it(
+      "filters diagnostics by Windows test filename from position_id",
+      function()
+        local test_entry = {
+          metadata = {
+            position_id = "D:\\\\\\\\a\\\\\\\\neotest-golang\\\\\\\\tests\\\\\\\\go\\\\\\\\internal\\\\\\\\multifile\\\\\\\\first_file_test.go::TestOne",
+            output_parts = {
+              table.concat({
+                "first_file_test.go:10: Starting Windows test",
+                "other_test.go:11: Should be ignored",
+              }, "\n"),
+              "  first_file_test.go:12: panic: Windows boom",
+              "go:13: some Windows harness line",
+            },
+          },
+        }
+
+        local errs = lib.diagnostics.process_diagnostics(test_entry)
+
+        assert.equals(2, #errs)
+
+        local by_line = {}
+        for _, e in ipairs(errs) do
+          by_line[e.line] = e
+        end
+
+        assert.is_not_nil(by_line[9])
+        assert.is_not_nil(by_line[11])
+        assert.equals("Starting Windows test", by_line[9].message)
+        assert.equals(vim.diagnostic.severity.HINT, by_line[9].severity)
+        assert.equals("panic: Windows boom", by_line[11].message)
+        assert.equals(vim.diagnostic.severity.ERROR, by_line[11].severity)
+      end
+    )
+
+    it("handles Windows UNC paths in position_id", function()
+      local test_entry = {
+        metadata = {
+          position_id = "\\\\\\\\\\\\\\\\server\\\\\\\\share\\\\\\\\project\\\\\\\\unc_test.go::TestUNC",
+          output_parts = {
+            "unc_test.go:5: UNC path diagnostic",
+            "other_file.go:6: Should be filtered out",
+          },
+        },
+      }
+
+      local errs = lib.diagnostics.process_diagnostics(test_entry)
+
+      assert.equals(1, #errs)
+      assert.equals(4, errs[1].line) -- 0-indexed
+      assert.equals("UNC path diagnostic", errs[1].message)
+    end)
+
+    it("handles Windows paths with mixed separators in position_id", function()
+      local test_entry = {
+        metadata = {
+          position_id = "C:\\\\\\\\Users\\\\\\\\test/project\\\\\\\\mixed_test.go::TestMixed",
+          output_parts = {
+            "mixed_test.go:15: Mixed separator test",
+          },
+        },
+      }
+
+      local errs = lib.diagnostics.process_diagnostics(test_entry)
+
+      assert.equals(1, #errs)
+      assert.equals(14, errs[1].line) -- 0-indexed
+      assert.equals("Mixed separator test", errs[1].message)
+    end)
+  end)
 end)

--- a/spec/unit/golist_spec.lua
+++ b/spec/unit/golist_spec.lua
@@ -1,5 +1,5 @@
 local lib = require("neotest-golang.lib")
-local utils = dofile(vim.uv.cwd() .. "/spec/helpers/utils.lua")
+local path = require("neotest-golang.lib.path")
 
 describe("go list output from root", function()
   it("contains expected keys/values", function()
@@ -8,10 +8,10 @@ describe("go list output from root", function()
     -- log.debug("Command:", vim.inspect(output))
     local first_entry = output[1]
     local expected = {
-      Dir = utils.normalize_path(tests_filepath .. "/cmd/main"),
+      Dir = path.normalize_path(tests_filepath .. "/cmd/main"),
       ImportPath = "github.com/fredrikaverpil/neotest-golang/cmd/main",
       Module = {
-        GoMod = utils.normalize_path(tests_filepath .. "/go.mod"),
+        GoMod = path.normalize_path(tests_filepath .. "/go.mod"),
       },
       Name = "main",
       TestGoFiles = {}, -- NOTE: added here because of custom `go list -f` command
@@ -27,7 +27,7 @@ describe("go list output from internal", function()
   it("contains expected keys/values", function()
     local tests_filepath = vim.uv.cwd() .. "/tests/go"
     local internal_filepath = vim.uv.cwd() .. "/tests/go/internal"
-    local output = lib.cmd.golist_data(utils.normalize_path(internal_filepath))
+    local output = lib.cmd.golist_data(path.normalize_path(internal_filepath))
 
     -- Find the positions package entry by ImportPath (order-agnostic)
     local positions_import =
@@ -43,10 +43,10 @@ describe("go list output from internal", function()
     assert.is_truthy(found)
 
     local expected = {
-      Dir = utils.normalize_path(internal_filepath .. "/positions"),
+      Dir = path.normalize_path(internal_filepath .. "/positions"),
       ImportPath = positions_import,
       Module = {
-        GoMod = utils.normalize_path(tests_filepath .. "/go.mod"),
+        GoMod = path.normalize_path(tests_filepath .. "/go.mod"),
       },
       Name = "positions",
       TestGoFiles = { "positions_test.go" },
@@ -62,13 +62,13 @@ describe("go list output from internal/positions", function()
   it("contains expected keys/values", function()
     local tests_filepath = vim.uv.cwd() .. "/tests/go"
     local positions_filepath = vim.uv.cwd() .. "/tests/go/internal/positions"
-    local output = lib.cmd.golist_data(utils.normalize_path(positions_filepath))
+    local output = lib.cmd.golist_data(path.normalize_path(positions_filepath))
     local first_entry = output[1]
     local expected = {
-      Dir = utils.normalize_path(positions_filepath),
+      Dir = path.normalize_path(positions_filepath),
       ImportPath = "github.com/fredrikaverpil/neotest-golang/internal/positions",
       Module = {
-        GoMod = utils.normalize_path(tests_filepath .. "/go.mod"),
+        GoMod = path.normalize_path(tests_filepath .. "/go.mod"),
       },
       Name = "positions",
       TestGoFiles = { "positions_test.go" },
@@ -84,24 +84,24 @@ describe("go list output from internal/nested", function()
   it("contains expected keys/values", function()
     local tests_filepath = vim.uv.cwd() .. "/tests/go"
     local filepath = vim.uv.cwd() .. "/tests/go/internal/nested"
-    local output = lib.cmd.golist_data(utils.normalize_path(filepath))
+    local output = lib.cmd.golist_data(path.normalize_path(filepath))
     local first_entry = output
     local expected = {
       {
-        Dir = utils.normalize_path(filepath .. "/subpackage2"),
+        Dir = path.normalize_path(filepath .. "/subpackage2"),
         ImportPath = "github.com/fredrikaverpil/neotest-golang/internal/nested/subpackage2",
         Module = {
-          GoMod = utils.normalize_path(tests_filepath .. "/go.mod"),
+          GoMod = path.normalize_path(tests_filepath .. "/go.mod"),
         },
         Name = "subpackage2",
         TestGoFiles = { "subpackage2_test.go" },
         XTestGoFiles = {}, -- NOTE: added here because of custom `go list -f` command
       },
       {
-        Dir = utils.normalize_path(filepath .. "/subpackage2/subpackage3"),
+        Dir = path.normalize_path(filepath .. "/subpackage2/subpackage3"),
         ImportPath = "github.com/fredrikaverpil/neotest-golang/internal/nested/subpackage2/subpackage3",
         Module = {
-          GoMod = utils.normalize_path(tests_filepath .. "/go.mod"),
+          GoMod = path.normalize_path(tests_filepath .. "/go.mod"),
         },
         Name = "subpackage3",
         TestGoFiles = { "subpackage3_test.go" },
@@ -118,14 +118,14 @@ describe("go list output from internal/packaging", function()
   it("contains expected keys/values", function()
     local tests_filepath = vim.uv.cwd() .. "/tests/go"
     local filepath = vim.uv.cwd() .. "/tests/go/internal/packaging"
-    local output = lib.cmd.golist_data(utils.normalize_path(filepath))
+    local output = lib.cmd.golist_data(path.normalize_path(filepath))
     local first_entry = output
     local expected = {
       {
-        Dir = utils.normalize_path(filepath),
+        Dir = path.normalize_path(filepath),
         ImportPath = "github.com/fredrikaverpil/neotest-golang/internal/packaging",
         Module = {
-          GoMod = utils.normalize_path(tests_filepath .. "/go.mod"),
+          GoMod = path.normalize_path(tests_filepath .. "/go.mod"),
         },
         Name = "packaging",
         TestGoFiles = { "whitebox_test.go" },
@@ -142,14 +142,14 @@ describe("go list output from internal/packaging", function()
   it("contains TestGoFiles and XTestGoFiles", function()
     local tests_filepath = vim.uv.cwd() .. "/tests/go"
     local filepath = vim.uv.cwd() .. "/tests/go/internal/packaging"
-    local output = lib.cmd.golist_data(utils.normalize_path(filepath))
+    local output = lib.cmd.golist_data(path.normalize_path(filepath))
     local first_entry = output
     local expected = {
       {
-        Dir = utils.normalize_path(filepath),
+        Dir = path.normalize_path(filepath),
         ImportPath = "github.com/fredrikaverpil/neotest-golang/internal/packaging",
         Module = {
-          GoMod = utils.normalize_path(tests_filepath .. "/go.mod"),
+          GoMod = path.normalize_path(tests_filepath .. "/go.mod"),
         },
         Name = "packaging",
         TestGoFiles = { "whitebox_test.go" },
@@ -166,14 +166,14 @@ describe("go list output from internal/multifile", function()
   it("contains two TestGoFiles", function()
     local tests_filepath = vim.uv.cwd() .. "/tests/go"
     local filepath = vim.uv.cwd() .. "/tests/go/internal/multifile"
-    local output = lib.cmd.golist_data(utils.normalize_path(filepath))
+    local output = lib.cmd.golist_data(path.normalize_path(filepath))
     local first_entry = output
     local expected = {
       {
-        Dir = utils.normalize_path(filepath),
+        Dir = path.normalize_path(filepath),
         ImportPath = "github.com/fredrikaverpil/neotest-golang/internal/multifile",
         Module = {
-          GoMod = utils.normalize_path(tests_filepath .. "/go.mod"),
+          GoMod = path.normalize_path(tests_filepath .. "/go.mod"),
         },
         Name = "multifile",
         TestGoFiles = { "first_file_test.go", "second_file_test.go" },
@@ -190,14 +190,14 @@ describe("go list output from internal/notests", function()
   it("contains no tests", function()
     local tests_filepath = vim.uv.cwd() .. "/tests/go"
     local filepath = vim.uv.cwd() .. "/tests/go/internal/notests"
-    local output = lib.cmd.golist_data(utils.normalize_path(filepath))
+    local output = lib.cmd.golist_data(path.normalize_path(filepath))
     local first_entry = output
     local expected = {
       {
-        Dir = utils.normalize_path(filepath),
+        Dir = path.normalize_path(filepath),
         ImportPath = "github.com/fredrikaverpil/neotest-golang/internal/notests",
         Module = {
-          GoMod = utils.normalize_path(tests_filepath .. "/go.mod"),
+          GoMod = path.normalize_path(tests_filepath .. "/go.mod"),
         },
         Name = "notests",
         TestGoFiles = {}, -- NOTE: added here because of custom `go list -f` command
@@ -301,14 +301,14 @@ describe("Windows path handling", function()
   it("verifies path normalization works with Windows paths", function()
     -- Test that normalize_path function handles Windows paths correctly
     local windows_path = "D:\\\\path\\\\to\\\\project"
-    local normalized = utils.normalize_path(windows_path)
+    local normalized = path.normalize_path(windows_path)
 
     -- The normalize_path should handle this gracefully (exact behavior may vary by platform)
     assert.is_truthy(normalized)
     assert.is_string(normalized)
 
     local unc_path = "\\\\\\\\server\\\\share\\\\folder"
-    local normalized_unc = utils.normalize_path(unc_path)
+    local normalized_unc = path.normalize_path(unc_path)
     assert.is_truthy(normalized_unc)
     assert.is_string(normalized_unc)
   end)

--- a/spec/unit/is_test_file_spec.lua
+++ b/spec/unit/is_test_file_spec.lua
@@ -16,4 +16,36 @@ describe("Is test file", function()
     local file_path = "foo_bar.go"
     assert.is_false(adapter.is_test_file(file_path))
   end)
+
+  describe("Windows path handling", function()
+    it("True - Windows path with backslashes", function()
+      local file_path = "foo\\bar\\baz_test.go"
+      assert.is_true(adapter.is_test_file(file_path))
+    end)
+
+    it("True - Windows path with drive letter", function()
+      local file_path = "C:\\Users\\test\\project\\foo_test.go"
+      assert.is_true(adapter.is_test_file(file_path))
+    end)
+
+    it("True - Windows UNC path", function()
+      local file_path = "\\\\server\\share\\project\\foo_test.go"
+      assert.is_true(adapter.is_test_file(file_path))
+    end)
+
+    it("True - Windows path with mixed separators", function()
+      local file_path = "C:\\Users\\test/project\\foo_test.go"
+      assert.is_true(adapter.is_test_file(file_path))
+    end)
+
+    it("False - Windows path but not a test file", function()
+      local file_path = "C:\\Users\\test\\project\\foo_bar.go"
+      assert.is_false(adapter.is_test_file(file_path))
+    end)
+
+    it("False - Windows path with different extension", function()
+      local file_path = "C:\\Users\\test\\project\\foo_test.txt"
+      assert.is_false(adapter.is_test_file(file_path))
+    end)
+  end)
 end)

--- a/spec/unit/mapping_spec.lua
+++ b/spec/unit/mapping_spec.lua
@@ -157,4 +157,134 @@ describe("mapping module", function()
       assert.are.same({}, result)
     end)
   end)
+
+  describe("Windows path handling", function()
+    describe("build_position_lookup with Windows paths", function()
+      local mock_tree_windows, mock_golist_data_windows
+
+      before_each(function()
+        -- Mock tree structure with Windows test nodes (using normalized paths for cross-platform testing)
+        local nodes = {
+          {
+            data = function()
+              return {
+                type = "test",
+                id = "D:/a/neotest-golang/tests/go/internal/multifile/first_file_test.go::TestOne",
+                path = "D:/a/neotest-golang/tests/go/internal/multifile/first_file_test.go",
+              }
+            end,
+          },
+          {
+            data = function()
+              return {
+                type = "test",
+                id = "D:/a/neotest-golang/tests/go/internal/multifile/second_file_test.go::TestTwo",
+                path = "D:/a/neotest-golang/tests/go/internal/multifile/second_file_test.go",
+              }
+            end,
+          },
+        }
+
+        mock_tree_windows = {
+          iter_nodes = function()
+            local i = 0
+            return function()
+              i = i + 1
+              return nodes[i], nodes[i]
+            end
+          end,
+        }
+
+        mock_golist_data_windows = {
+          {
+            ImportPath = "github.com/fredrikaverpil/neotest-golang/internal/multifile",
+            Dir = "D:/a/neotest-golang/tests/go/internal/multifile",
+          },
+        }
+      end)
+
+      it("builds lookup table for Windows paths correctly", function()
+        local result = lib.mapping.build_position_lookup(
+          mock_tree_windows,
+          mock_golist_data_windows
+        )
+
+        -- Should correctly map Windows paths with drive letters
+        assert.are.equal(
+          "D:/a/neotest-golang/tests/go/internal/multifile/first_file_test.go::TestOne",
+          result["github.com/fredrikaverpil/neotest-golang/internal/multifile::TestOne"]
+        )
+        assert.are.equal(
+          "D:/a/neotest-golang/tests/go/internal/multifile/second_file_test.go::TestTwo",
+          result["github.com/fredrikaverpil/neotest-golang/internal/multifile::TestTwo"]
+        )
+      end)
+
+      it("does not break on Windows drive letter colons", function()
+        -- This is a regression test for the specific issue where Windows drive letter colons
+        -- were causing path extraction to fail
+        local result = lib.mapping.build_position_lookup(
+          mock_tree_windows,
+          mock_golist_data_windows
+        )
+
+        -- Make sure we don't have broken entries due to colon confusion
+        local keys = vim.tbl_keys(result)
+        for _, key in ipairs(keys) do
+          -- No entry should contain just "D" or other single drive letters
+          assert.is_not.equal("D", key)
+          assert.is_not.equal("C", key)
+        end
+
+        -- Verify the correct full paths are in the keys
+        local has_correct_key = false
+        for _, key in ipairs(keys) do
+          if
+            key:find(
+              "github.com/fredrikaverpil/neotest%-golang/internal/multifile::TestOne"
+            )
+          then
+            has_correct_key = true
+            break
+          end
+        end
+        assert.is_true(
+          has_correct_key,
+          "Should have correct lookup key for TestOne"
+        )
+      end)
+    end)
+
+    describe("get_pos_id with Windows paths", function()
+      local lookup_table_windows
+
+      before_each(function()
+        lookup_table_windows = {
+          ["github.com/repo/pkg::TestName"] = "D:\\\\path\\\\to\\\\pkg\\\\file_test.go::TestName",
+          ["github.com/repo/pkg::TestName/SubTest"] = 'D:\\\\path\\\\to\\\\pkg\\\\file_test.go::TestName::"SubTest"',
+        }
+      end)
+
+      it("finds Windows position ID for simple test", function()
+        local package_name = "github.com/repo/pkg"
+        local test_name = "TestName"
+        local expected = "D:\\\\path\\\\to\\\\pkg\\\\file_test.go::TestName"
+
+        local result =
+          lib.mapping.get_pos_id(lookup_table_windows, package_name, test_name)
+        assert.are.equal(expected, result)
+      end)
+
+      it("finds Windows position ID for nested subtest", function()
+        local package_name = "github.com/repo/pkg"
+        local test_name = "TestName/SubTest"
+        local expected =
+          'D:\\\\path\\\\to\\\\pkg\\\\file_test.go::TestName::"SubTest"'
+
+        local result =
+          lib.mapping.get_pos_id(lookup_table_windows, package_name, test_name)
+        assert.are.equal(expected, result)
+      end)
+    end)
+  end)
 end)


### PR DESCRIPTION
### Why?

I unfortunately forgot about Windows...

### What?

- Enable Windows (and macOS) tests in CI, in addition to the existing matrix that only had Linux in it.
- Add debugging steps to CI for `go list` and `go test`.
- Add Neovim logs to failing tests in CI.
- Add unit tests for Windows and UNC paths.
- Replace a bunch of `vim.fn|fs.*` functions which does not handle Windows paths well with custom functions.
- Use proper OS path separator.
- Add caching for performance/optimization in hot path.
- Add `path` module to specifically address the Windows/UNC/POSIX difficulties.

Fixes #415