### PR TITLE
fix: show options in debug log

### DIFF
--- a/lua/neotest-golang/init.lua
+++ b/lua/neotest-golang/init.lua
@@ -197,7 +197,8 @@ end
 --- Adapter options.
 setmetatable(M.Adapter, {
   __call = function(_, opts)
-    M.Adapter.options = options.setup(opts)
+    options.setup(opts)
+    M.Adapter.options = options.get()
     logger.debug(
       "Adapter loaded with options: " .. vim.inspect(M.Adapter.options)
     )

--- a/lua/neotest-golang/options.lua
+++ b/lua/neotest-golang/options.lua
@@ -52,7 +52,6 @@ function M.setup(user_opts)
     for k, v in pairs(user_opts) do
       opts[k] = v
     end
-  else
   end
 end
 


### PR DESCRIPTION
I kept seeing this line in the debug log `Adapter loaded with options: nil`.

Fix this by using the provided getter of options.