### PR TITLE
fix: remove use of statement_list for tree-sitter 0.25.10

### DIFF
--- a/lua/neotest-golang/queries/go/table_tests_inline_field_access.scm
+++ b/lua/neotest-golang/queries/go/table_tests_inline_field_access.scm
@@ -45,17 +45,16 @@
               (literal_element
                 (interpreted_string_literal) @test.name))) @test.definition))))
   body: (block
-    (statement_list
-      (expression_statement
-        (call_expression
-          function: (selector_expression
-            operand: (identifier) @test.operand
-            (#match? @test.operand "^[t]$")
-            field: (field_identifier) @test.method
-            (#match? @test.method "^Run$"))
-          arguments: (argument_list
-            (selector_expression
-              operand: (identifier) @test.case1
-              (#eq? @test.case @test.case1)
-              field: (field_identifier) @test.field.name1
-              (#eq? @test.field.name @test.field.name1))))))))
+    (expression_statement
+      (call_expression
+        function: (selector_expression
+          operand: (identifier) @test.operand
+          (#match? @test.operand "^[t]$")
+          field: (field_identifier) @test.method
+          (#match? @test.method "^Run$"))
+        arguments: (argument_list
+          (selector_expression
+            operand: (identifier) @test.case1
+            (#eq? @test.case @test.case1)
+            field: (field_identifier) @test.field.name1
+            (#eq? @test.field.name @test.field.name1)))))))

--- a/lua/neotest-golang/queries/go/table_tests_list.scm
+++ b/lua/neotest-golang/queries/go/table_tests_list.scm
@@ -27,38 +27,36 @@
 ; The query validates that the same field is used in both the struct and t.Run().
 ; ============================================================================
 (block
-  (statement_list
-    (short_var_declaration
+  (short_var_declaration
+    left: (expression_list
+      (identifier) @test.cases)
+    right: (expression_list
+      (composite_literal
+        (literal_value
+          (literal_element
+            (literal_value
+              (keyed_element
+                (literal_element
+                  (identifier) @test.field.name)
+                (literal_element
+                  (interpreted_string_literal) @test.name)))) @test.definition))))
+  (for_statement
+    (range_clause
       left: (expression_list
-        (identifier) @test.cases)
-      right: (expression_list
-        (composite_literal
-          (literal_value
-            (literal_element
-              (literal_value
-                (keyed_element
-                  (literal_element
-                    (identifier) @test.field.name)
-                  (literal_element
-                    (interpreted_string_literal) @test.name)))) @test.definition))))
-    (for_statement
-      (range_clause
-        left: (expression_list
-          (identifier) @test.case)
-        right: (identifier) @test.cases1
-        (#eq? @test.cases @test.cases1))
-      body: (block
-        (statement_list
-          (expression_statement
-            (call_expression
-              function: (selector_expression
-                operand: (identifier) @test.operand
-                (#match? @test.operand "^[t]$")
-                field: (field_identifier) @test.method
-                (#match? @test.method "^Run$"))
-              arguments: (argument_list
-                (selector_expression
-                  operand: (identifier) @test.case1
-                  (#eq? @test.case @test.case1)
-                  field: (field_identifier) @test.field.name1
-                  (#eq? @test.field.name @test.field.name1))))))))))
+        (identifier) @test.case)
+      right: (identifier) @test.cases1
+      (#eq? @test.cases @test.cases1))
+    body: (block
+      (expression_statement
+        (call_expression
+          function: (selector_expression
+            operand: (identifier) @test.operand
+            (#match? @test.operand "^[t]$")
+            field: (field_identifier) @test.method
+            (#match? @test.method "^Run$"))
+          arguments: (argument_list
+            (selector_expression
+              operand: (identifier) @test.case1
+              (#eq? @test.case @test.case1)
+              field: (field_identifier) @test.field.name1
+              (#eq? @test.field.name @test.field.name1))))))))

--- a/lua/neotest-golang/queries/go/table_tests_loop.scm
+++ b/lua/neotest-golang/queries/go/table_tests_loop.scm
@@ -50,14 +50,13 @@
               (literal_element
                 (interpreted_string_literal) @test.name))) @test.definition))))
   body: (block
-    (statement_list
-      (expression_statement
-        (call_expression
-          function: (selector_expression
+    (expression_statement
+      (call_expression
+        function: (selector_expression
+          operand: (identifier)
+          field: (field_identifier))
+        arguments: (argument_list
+          (selector_expression
             operand: (identifier)
-            field: (field_identifier))
-          arguments: (argument_list
-            (selector_expression
-              operand: (identifier)
-              field: (field_identifier) @test.field.name1)
-            (#eq? @test.field.name @test.field.name1)))))))
+            field: (field_identifier) @test.field.name1)
+          (#eq? @test.field.name @test.field.name1))))))

--- a/lua/neotest-golang/queries/go/table_tests_loop_unkeyed.scm
+++ b/lua/neotest-golang/queries/go/table_tests_loop_unkeyed.scm
@@ -52,17 +52,16 @@
               (interpreted_string_literal) @test.name)
             (literal_element)) @test.definition))))
   body: (block
-    (statement_list
-      (expression_statement
-        (call_expression
-          function: (selector_expression
-            operand: (identifier) @test.operand
-            (#match? @test.operand "^[t]$")
-            field: (field_identifier) @test.method
-            (#match? @test.method "^Run$"))
-          arguments: (argument_list
-            (selector_expression
-              operand: (identifier) @test.case1
-              (#eq? @test.case @test.case1)
-              field: (field_identifier) @test.field.name1
-              (#eq? @test.field.name @test.field.name1))))))))
+    (expression_statement
+      (call_expression
+        function: (selector_expression
+          operand: (identifier) @test.operand
+          (#match? @test.operand "^[t]$")
+          field: (field_identifier) @test.method
+          (#match? @test.method "^Run$"))
+        arguments: (argument_list
+          (selector_expression
+            operand: (identifier) @test.case1
+            (#eq? @test.case @test.case1)
+            field: (field_identifier) @test.field.name1
+            (#eq? @test.field.name @test.field.name1)))))))

--- a/lua/neotest-golang/queries/go/table_tests_map.scm
+++ b/lua/neotest-golang/queries/go/table_tests_map.scm
@@ -27,34 +27,32 @@
 ; The map key becomes the test name, making it unique from slice-based patterns.
 ; ============================================================================
 (block
-  (statement_list
-    (short_var_declaration
+  (short_var_declaration
+    left: (expression_list
+      (identifier) @test.cases)
+    right: (expression_list
+      (composite_literal
+        (literal_value
+          (keyed_element
+            (literal_element
+              (interpreted_string_literal) @test.name)
+            (literal_element
+              (literal_value) @test.definition))))))
+  (for_statement
+    (range_clause
       left: (expression_list
-        (identifier) @test.cases)
-      right: (expression_list
-        (composite_literal
-          (literal_value
-            (keyed_element
-              (literal_element
-                (interpreted_string_literal) @test.name)
-              (literal_element
-                (literal_value) @test.definition))))))
-    (for_statement
-      (range_clause
-        left: (expression_list
-          (identifier) @test.key.name
-          (identifier) @test.case)
-        right: (identifier) @test.cases1
-        (#eq? @test.cases @test.cases1))
-      body: (block
-        (statement_list
-          (expression_statement
-            (call_expression
-              function: (selector_expression
-                operand: (identifier) @test.operand
-                (#match? @test.operand "^[t]$")
-                field: (field_identifier) @test.method
-                (#match? @test.method "^Run$"))
-              arguments: (argument_list
-                ((identifier) @test.key.name1
-                  (#eq? @test.key.name @test.key.name1))))))))))
+        (identifier) @test.key.name
+        (identifier) @test.case)
+      right: (identifier) @test.cases1
+      (#eq? @test.cases @test.cases1))
+    body: (block
+      (expression_statement
+        (call_expression
+          function: (selector_expression
+            operand: (identifier) @test.operand
+            (#match? @test.operand "^[t]$")
+            field: (field_identifier) @test.method
+            (#match? @test.method "^Run$"))
+          arguments: (argument_list
+            ((identifier) @test.key.name1
+              (#eq? @test.key.name @test.key.name1))))))))

--- a/lua/neotest-golang/queries/go/table_tests_unkeyed.scm
+++ b/lua/neotest-golang/queries/go/table_tests_unkeyed.scm
@@ -31,36 +31,34 @@
 ; Compare to table_tests_list.scm which uses {name: "test1"} syntax.
 ; ============================================================================
 (block
-  (statement_list
-    (short_var_declaration
+  (short_var_declaration
+    left: (expression_list
+      (identifier) @test.cases)
+    right: (expression_list
+      (composite_literal
+        body: (literal_value
+          (literal_element
+            (literal_value
+              .
+              (literal_element
+                (interpreted_string_literal) @test.name)
+              (literal_element)) @test.definition)))))
+  (for_statement
+    (range_clause
       left: (expression_list
-        (identifier) @test.cases)
-      right: (expression_list
-        (composite_literal
-          body: (literal_value
-            (literal_element
-              (literal_value
-                .
-                (literal_element
-                  (interpreted_string_literal) @test.name)
-                (literal_element)) @test.definition)))))
-    (for_statement
-      (range_clause
-        left: (expression_list
-          (identifier) @test.key.name
-          (identifier) @test.case)
-        right: (identifier) @test.cases1
-        (#eq? @test.cases @test.cases1))
-      body: (block
-        (statement_list
-          (expression_statement
-            (call_expression
-              function: (selector_expression
-                operand: (identifier) @test.operand
-                (#match? @test.operand "^[t]$")
-                field: (field_identifier) @test.method
-                (#match? @test.method "^Run$"))
-              arguments: (argument_list
-                (selector_expression
-                  operand: (identifier) @test.case1
-                  (#eq? @test.case @test.case1))))))))))
+        (identifier) @test.key.name
+        (identifier) @test.case)
+      right: (identifier) @test.cases1
+      (#eq? @test.cases @test.cases1))
+    body: (block
+      (expression_statement
+        (call_expression
+          function: (selector_expression
+            operand: (identifier) @test.operand
+            (#match? @test.operand "^[t]$")
+            field: (field_identifier) @test.method
+            (#match? @test.method "^Run$"))
+          arguments: (argument_list
+            (selector_expression
+              operand: (identifier) @test.case1
+              (#eq? @test.case @test.case1))))))))


### PR DESCRIPTION
This package broke for me after upgrading to tree-sitter 0.25.10. Had a quick look and it seems like `statement_list` no longer works for the treesitter queries. Removing that part of the statements fixes the issue for me.

Probably shouldn't merge this just yet though, since it will break everyone on the older version.