### PR TITLE
docs: fix missing comma in installation example

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -22,7 +22,7 @@ return {
       "antoinemadec/FixCursorHold.nvim",
       {
         "nvim-treesitter/nvim-treesitter", -- Optional, but recommended
-        branch = "main"  -- NOTE; not the master branch!
+        branch = "main",  -- NOTE; not the master branch!
         build = function()
           vim.cmd(":TSUpdate go")
         end,


### PR DESCRIPTION
Fixes typo in installation example.

The code snippet was missing a comma, causing syntax errors when copied.