### PR TITLE
fix(dap): restart by disabling delve's native restart capability

### DIFF
--- a/lua/neotest-golang/features/dap/dap_go.lua
+++ b/lua/neotest-golang/features/dap/dap_go.lua
@@ -28,6 +28,15 @@ function M.setup_debugging(cwd)
     })
     require("dap-go").setup(dap_go_opts_original)
   end
+
+  -- Workaround: Disable native restart to force terminate+rerun.
+  -- Delve's native DAP restart doesn't work reliably for test debugging.
+  -- See: https://github.com/go-delve/delve/issues/4102
+  require("dap").listeners.after.event_initialized["neotest-golang-debug"] = function(
+    session
+  )
+    session.capabilities.supportsRestartRequest = false
+  end
 end
 
 --- @param test_path string


### PR DESCRIPTION
## Why?

When debugging Go tests via neotest-golang and attempting to restart the debug session using nvim-dap-ui's restart button, the restart would fail silently. Users would see "Restarted debug adapter" notification but nothing would actually happen - the test would not restart.

This occurs because:
1. Delve v1.25+ sets `supportsRestartRequest = true` in its DAP capabilities
2. nvim-dap sees this capability and sends a native `restart` DAP request instead of terminate+rerun
3. Delve acknowledges the restart request but doesn't properly restart test debugging sessions
4. The debug session becomes stuck with no way to restart without manually terminating

## What?

- Added a new DAP listener on `event_initialized` that disables the `supportsRestartRequest` capability for neotest-golang debug sessions
- This forces nvim-dap to use the terminate+rerun path instead of Delve's native restart
- The terminate+rerun approach works reliably: it properly terminates the current session and starts a fresh debug session

## Notes

- This is a workaround for a Delve DAP issue: https://github.com/go-delve/delve/issues/4102
- Related Delve fix (partial): https://github.com/go-delve/delve/pull/4103
- VS Code Go had the same issue: https://github.com/golang/vscode-go/issues/3835
- This workaround can be removed once Delve's native restart works reliably for test debugging