### PR TITLE
fix(dap): remove nvim-dap workaround for restarting dlv

### DIFF
--- a/lua/neotest-golang/features/dap/dap_go.lua
+++ b/lua/neotest-golang/features/dap/dap_go.lua
@@ -28,18 +28,6 @@ function M.setup_debugging(cwd)
     })
     require("dap-go").setup(dap_go_opts_original)
   end
-
-  -- Workaround: Disable native restart to force terminate+rerun.
-  -- Delve supports restart with rebuild (go-delve/delve#4103), but nvim-dap
-  -- doesn't format the restart request correctly (missing `arguments.rebuild`).
-  -- Until nvim-dap supports proper restart arguments, we force terminate+rerun.
-  -- See: https://github.com/go-delve/delve/issues/4102
-  -- See: https://github.com/mfussenegger/nvim-dap/issues/1575
-  require("dap").listeners.after.event_initialized["neotest-golang-debug"] = function(
-    session
-  )
-    session.capabilities.supportsRestartRequest = false
-  end
 end
 
 --- @param test_path string


### PR DESCRIPTION
Since nvim-dap now supports dap restart arguments properly, we can
remove the workaround.

Requires:
- dlv >= 1.24.0 with https://github.com/go-delve/delve/pull/4103
- nvim-dap with commit 7bb46cc from https://github.com/mfussenegger/nvim-dap/pull/1576