### PR TITLE
chore(deps): update pocket to latest

### DIFF
--- a/.pocket/go.mod
+++ b/.pocket/go.mod
@@ -2,7 +2,7 @@ module pocket
 
 go 1.26.1
 
-require github.com/fredrikaverpil/pocket v0.0.0-20260315084410-bafaf8ac24a7
+require github.com/fredrikaverpil/pocket v0.0.0-20260315110739-a2539deb8a86
 
 require (
 	golang.org/x/sync v0.19.0 // indirect

--- a/.pocket/go.mod
+++ b/.pocket/go.mod
@@ -2,7 +2,7 @@ module pocket
 
 go 1.26.1
 
-require github.com/fredrikaverpil/pocket v0.0.0-20260308194944-4f1fb270392b
+require github.com/fredrikaverpil/pocket v0.0.0-20260315084410-bafaf8ac24a7
 
 require (
 	golang.org/x/sync v0.19.0 // indirect

--- a/.pocket/go.sum
+++ b/.pocket/go.sum
@@ -1,5 +1,5 @@
-github.com/fredrikaverpil/pocket v0.0.0-20260315084410-bafaf8ac24a7 h1:gj988YZWD+PJq/JLfmmakm5iIvRjOX7UMYw7qLnUOaI=
-github.com/fredrikaverpil/pocket v0.0.0-20260315084410-bafaf8ac24a7/go.mod h1:/Yrpyu8n8psheBv/3pVgIoz+KVsWwSy0ueU7xzOKf4w=
+github.com/fredrikaverpil/pocket v0.0.0-20260315110739-a2539deb8a86 h1:jCEAUeR9K1pwwL9xzzU63joIxUVIGRtlVjAQw9A0xQQ=
+github.com/fredrikaverpil/pocket v0.0.0-20260315110739-a2539deb8a86/go.mod h1:/Yrpyu8n8psheBv/3pVgIoz+KVsWwSy0ueU7xzOKf4w=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=

--- a/.pocket/go.sum
+++ b/.pocket/go.sum
@@ -1,5 +1,5 @@
-github.com/fredrikaverpil/pocket v0.0.0-20260308194944-4f1fb270392b h1:SwmmNR5iSf8W7fwuVNyrCcrZsZ4qgwi2d5MkeccY9X0=
-github.com/fredrikaverpil/pocket v0.0.0-20260308194944-4f1fb270392b/go.mod h1:/Yrpyu8n8psheBv/3pVgIoz+KVsWwSy0ueU7xzOKf4w=
+github.com/fredrikaverpil/pocket v0.0.0-20260315084410-bafaf8ac24a7 h1:gj988YZWD+PJq/JLfmmakm5iIvRjOX7UMYw7qLnUOaI=
+github.com/fredrikaverpil/pocket v0.0.0-20260315084410-bafaf8ac24a7/go.mod h1:/Yrpyu8n8psheBv/3pVgIoz+KVsWwSy0ueU7xzOKf4w=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=


### PR DESCRIPTION
## Why
Update Pocket dependency to the latest version.

## What
- Update `.pocket/go.mod` and `.pocket/go.sum` to use Pocket at commit `bafaf8ac24a71e0aac316db8ce2ecf3d6778f307`