### PR TITLE
fix: only load nvim-treesitter if available

### DIFF
--- a/lua/neotest-golang/features/testify/query.lua
+++ b/lua/neotest-golang/features/testify/query.lua
@@ -5,7 +5,9 @@ local query_loader = require("neotest-golang.lib.query_loader")
 
 -- NOTE: this import cannot be removed. If removing it, lua tests will fail with:
 -- E5560: nvim_create_augroup must not be called in a fast event context.
-require("nvim-treesitter")
+if package.loaded["nvim-treesitter"] then
+  require("nvim-treesitter")
+end
 
 local M = {}
 


### PR DESCRIPTION
### Why?

When depending on neotest-golang in your config, if you don't have nvim-treesitter installed, you will see an error like

```lua
...est-golang/lua/neotest-golang/features/testify/query.lua:8: module 'nvim-treesitter' not found:
no field package.preload['nvim-treesitter']
cache_loader: module 'nvim-treesitter' not found
cache_loader_lib: module 'nvim-treesitter' not found

...
```

### What?

Wrap the `require` statement in `if package.loaded...`.
