### PR TITLE
feat: validate struct field name in unkeyed table test discovery

### DIFF
--- a/lua/neotest-golang/queries/go/table_tests_loop_unkeyed.scm
+++ b/lua/neotest-golang/queries/go/table_tests_loop_unkeyed.scm
@@ -40,6 +40,7 @@
       type: (slice_type
         element: (struct_type
           (field_declaration_list
+            .
             (field_declaration
               name: (field_identifier) @test.field.name
               type: (type_identifier) @field.type

--- a/lua/neotest-golang/queries/go/table_tests_unkeyed.scm
+++ b/lua/neotest-golang/queries/go/table_tests_unkeyed.scm
@@ -26,6 +26,11 @@
 ; What gets captured:
 ; - @test.name = The first string literal in the struct (e.g., "test1")
 ; - @test.definition = The entire struct literal (e.g., {"test1", 1})
+; - @test.field.name = The first string field from struct type (e.g., "name")
+;
+; The query validates that the field used in t.Run() matches the first string
+; field declared in the struct type. This prevents capturing wrong string
+; literals when the struct has multiple string fields.
 ;
 ; DISTINGUISHING FEATURE: No field names in the struct literal.
 ; Compare to table_tests_list.scm which uses {name: "test1"} syntax.
@@ -37,6 +42,14 @@
         (identifier) @test.cases)
       right: (expression_list
         (composite_literal
+          type: (slice_type
+            element: (struct_type
+              (field_declaration_list
+                .
+                (field_declaration
+                  name: (field_identifier) @test.field.name
+                  type: (type_identifier) @field.type
+                  (#eq? @field.type "string")))))
           body: (literal_value
             (literal_element
               (literal_value
@@ -63,4 +76,6 @@
               arguments: (argument_list
                 (selector_expression
                   operand: (identifier) @test.case1
-                  (#eq? @test.case @test.case1))))))))))
+                  (#eq? @test.case @test.case1)
+                  field: (field_identifier) @test.field.name1
+                  (#eq? @test.field.name @test.field.name1))))))))))

--- a/spec/integration/positions_spec.lua
+++ b/spec/integration/positions_spec.lua
@@ -82,6 +82,14 @@ describe("Integration: positions test", function()
             status = "passed",
             errors = {},
           },
+          [position_id .. "::TestTableTestMultipleStringFieldsUnkeyed"] = {
+            status = "passed",
+            errors = {},
+          },
+          [position_id .. "::TestTableTestSecondStringFieldUnkeyed"] = {
+            status = "passed",
+            errors = {},
+          },
           [position_id .. "::TestStructNotTableTest"] = {
             status = "passed",
             errors = {},
@@ -180,6 +188,18 @@ describe("Integration: positions test", function()
             errors = {},
           },
           [position_id .. '::TestTableTestInlineCompositeWithFieldAccess::"user2"'] = {
+            status = "passed",
+            errors = {},
+          },
+          [position_id .. '::TestTableTestMultipleStringFieldsUnkeyed::"x"'] = {
+            status = "passed",
+            errors = {},
+          },
+          [position_id .. '::TestTableTestMultipleStringFieldsUnkeyed::"y"'] = {
+            status = "passed",
+            errors = {},
+          },
+          [position_id .. '::TestTableTestMultipleStringFieldsUnkeyed::"z"'] = {
             status = "passed",
             errors = {},
           },

--- a/spec/integration/positions_spec.lua
+++ b/spec/integration/positions_spec.lua
@@ -90,6 +90,10 @@ describe("Integration: positions test", function()
             status = "passed",
             errors = {},
           },
+          [position_id .. "::TestTableTestNamedStructUnkeyed"] = {
+            status = "passed",
+            errors = {},
+          },
           [position_id .. "::TestStructNotTableTest"] = {
             status = "passed",
             errors = {},

--- a/tests/go/internal/positions/positions_test.go
+++ b/tests/go/internal/positions/positions_test.go
@@ -269,8 +269,9 @@ func TestTableTestMultipleStringFieldsUnkeyed(t *testing.T) {
 }
 
 // Table test where t.Run uses the second string field (desc, not name).
-// No subtests should be discovered because the first positional string
-// does not correspond to the field used in t.Run.
+// Subtests are NOT discovered because the query only matches when t.Run
+// uses the first string field in the struct. This documents a known
+// limitation that prevents capturing wrong test names.
 func TestTableTestSecondStringFieldUnkeyed(t *testing.T) {
 	testCases := []struct {
 		name  string
@@ -284,6 +285,27 @@ func TestTableTestSecondStringFieldUnkeyed(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			if tc.name == "" {
+				t.Fail()
+			}
+		})
+	}
+}
+
+// Table test with a named struct type and unkeyed (positional) literals.
+// Subtests are NOT discovered because the query requires an inline struct
+// definition to validate field names. This documents a known limitation.
+func TestTableTestNamedStructUnkeyed(t *testing.T) {
+	type tc struct {
+		name string
+		want int
+	}
+	tests := []tc{
+		{"test1", 1},
+		{"test2", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.want == 0 {
 				t.Fail()
 			}
 		})

--- a/tests/go/internal/positions/positions_test.go
+++ b/tests/go/internal/positions/positions_test.go
@@ -245,6 +245,51 @@ func TestTableTestInlineCompositeWithFieldAccess(t *testing.T) {
 	}
 }
 
+// Table test with multiple string fields and unkeyed struct literals.
+// Only the field used in t.Run (name) should be discovered as test name.
+// The desc field should NOT appear as a test name.
+func TestTableTestMultipleStringFieldsUnkeyed(t *testing.T) {
+	testCases := []struct {
+		name  string
+		desc  string
+		valid bool
+	}{
+		{"x", "John Doe", true},
+		{name: "y", desc: "J d", valid: true},
+		{"z", "  John   Doe  ", true},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			if tC.desc == "" {
+				t.Fail()
+			}
+		})
+	}
+}
+
+// Table test where t.Run uses the second string field (desc, not name).
+// No subtests should be discovered because the first positional string
+// does not correspond to the field used in t.Run.
+func TestTableTestSecondStringFieldUnkeyed(t *testing.T) {
+	testCases := []struct {
+		name  string
+		desc  string
+		valid bool
+	}{
+		{"x", "John Doe", true},
+		{"y", "Jane Doe", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			if tc.name == "" {
+				t.Fail()
+			}
+		})
+	}
+}
+
 // Struct which is not a table test.
 func TestStructNotTableTest(t *testing.T) {
 	type item struct {


### PR DESCRIPTION
The tree-sitter query for unkeyed table tests now checks that the struct field used in t.Run() matches the first string-typed field in the struct declaration. This prevents discovering wrong test names when a struct has multiple string fields.

Closes #417