### PR TITLE
chore: add .luarc.json to avoid indexing undesired files for LSP

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+  "runtime.version": "LuaJIT",
+  "workspace.checkThirdParty": false,
+  "workspace.ignoreDir": [".pocket/tools"],
+  "workspace.library": ["$VIMRUNTIME"]
+}


### PR DESCRIPTION
This error is getting hit in this project:

```
LSP[lua_ls] More than 100000 files have been scanned. The current scanned directory is `/Users/fredrik/code/public/github.com/fredrikaverpil/neotest-golang`. Please see the [FAQ](https://luals.github.io/wiki/faq/#how-can-i-improve-startup-speeds) to see how you can include fewer files. It is also possible that your [configuration is incorrect](https://luals.github.io/wiki/faq#why-is-the-server-scanning-the-wrong-folder).
```