### PR TITLE
fix(results): skip result parsing for files without tests

### DIFF
--- a/lua/neotest-golang/lib/types.lua
+++ b/lua/neotest-golang/lib/types.lua
@@ -5,6 +5,7 @@
 --- @field golist_data table<string, string> The 'go list' JSON data (lua table).
 --- @field errors? table<string> Non-gotest errors to show in the final output.
 --- @field is_dap_active boolean? If true, parsing of test output will occur.
+--- @field skipped? boolean If true, the position has no tests and result parsing is skipped.
 --- @field test_output_json_filepath? string Gotestsum JSON filepath.
 --- @field stop_filestream fun() Stops the stream of test output.
 --- @field process_test_results? boolean Used in test.lua specifically

--- a/lua/neotest-golang/results_finalize.lua
+++ b/lua/neotest-golang/results_finalize.lua
@@ -49,6 +49,15 @@ function M.test_results(spec, result, tree)
     return skipped_result
   end
 
+  if context.skipped then
+    -- The position has no tests to run (e.g. a file without Go test functions),
+    -- so there is no test output to parse.
+    skipped_result[context.pos_id] = {
+      status = "skipped",
+    }
+    return skipped_result
+  end
+
   --- The runner to use for running tests.
   --- @type string
   local runner = options.get().runner

--- a/lua/neotest-golang/runspec/file.lua
+++ b/lua/neotest-golang/runspec/file.lua
@@ -129,6 +129,7 @@ function M.return_skipped(pos)
   local context = {
     pos_id = pos.id,
     golist_data = {}, -- no golist output
+    skipped = true, -- no tests to run, skip result parsing
     stop_filestream = function() end, -- no stream to stop
   }
 

--- a/spec/unit/results_finalize_spec.lua
+++ b/spec/unit/results_finalize_spec.lua
@@ -1,0 +1,43 @@
+local _ = require("plenary")
+local options = require("neotest-golang.options")
+local results_finalize = require("neotest-golang.results_finalize")
+
+describe("results_finalize.test_results", function()
+  -- A skipped runspec is produced for positions without tests (e.g. a file
+  -- without Go test functions). Such a runspec carries no test output to parse,
+  -- so result finalization must short-circuit regardless of the configured
+  -- runner. Previously the "gotestsum" runner threw "Gotestsum JSON output file
+  -- path not provided" in this case (issue #574).
+  local runners = {
+    { name = "go runner", runner = "go" },
+    { name = "gotestsum runner", runner = "gotestsum" },
+  }
+
+  for _, case in ipairs(runners) do
+    it("returns a skipped result for the " .. case.name, function()
+      -- Arrange
+      options.setup({ runner = case.runner })
+      local pos_id = "/path/to/file_test.go"
+      local spec = {
+        context = {
+          pos_id = pos_id,
+          golist_data = {},
+          skipped = true,
+          stop_filestream = function() end,
+        },
+      }
+      local result = { code = 0 }
+      local tree = {
+        data = function()
+          return { id = pos_id }
+        end,
+      }
+
+      -- Act
+      local got = results_finalize.test_results(spec, result, tree)
+
+      -- Assert
+      assert.are_same({ [pos_id] = { status = "skipped" } }, got)
+    end)
+  end
+end)


### PR DESCRIPTION
## Why?

- Running a position with no discoverable Go test functions (e.g. selecting a
  file that has no `func Test...`) crashes with a misleading error under the
  `gotestsum` runner:

  ```
  neotest-golang: ...lib/logging.lua:144: Gotestsum JSON output file path not provided
  ```

- The file runspec builder returns a *skipped* runspec via `return_skipped`,
  but `results_finalize.test_results` had no early return for it, so it fell
  into the runner branch where `context.test_output_json_filepath` is `nil` and
  `logger.error(...)` throws.
- The `go` runner only tolerated this by accident (the skipped runspec's `echo`
  output happened to be readable). Fixes #574.

## What?

- Mark the skipped runspec's context with `skipped = true` in `return_skipped`.
- Short-circuit in `results_finalize.test_results`, mirroring the existing DAP
  early return, so both runners return a `skipped` result:

  ```lua
  if context.skipped then
    skipped_result[context.pos_id] = { status = "skipped" }
    return skipped_result
  end
  ```

- Add a unit test covering both runners.

## Notes

- User-facing "No tests found in file" warning is already emitted by the file
  runspec builder, so the experience now degrades gracefully instead of throwing.