### PR TITLE
fix: use vim.fn.expand for home path

### DIFF
--- a/lua/neotest-golang/health.lua
+++ b/lua/neotest-golang/health.lua
@@ -95,7 +95,7 @@ function M.is_problematic_path()
       Darwin = {
         "/private/tmp",
         "/tmp",
-        lib.path.normalize_path(os.getenv("HOME") .. "/Public"),
+        lib.path.normalize_path(vim.fn.expand("$HOME") .. "/Public"),
       },
       Linux = { "/tmp" },
     }

--- a/lua/neotest-golang/health.lua
+++ b/lua/neotest-golang/health.lua
@@ -85,24 +85,26 @@ function M.go_mod_found()
 end
 
 function M.is_problematic_path()
-  local go_mod_filepath = nil
+  local sysname = vim.uv.os_uname().sysname
+
+  local problematic_paths = nil
+  if sysname == "Darwin" then
+    problematic_paths = {
+      "/private/tmp",
+      "/tmp",
+      lib.path.normalize_path(vim.fn.expand("$HOME") .. "/Public"),
+    }
+  elseif sysname == "Linux" then
+    problematic_paths = { "/tmp" }
+  else
+    return
+  end
+
   local filepaths = lib.find.go_test_filepaths(vim.fn.getcwd())
   for _, filepath in ipairs(filepaths) do
     local start_path = lib.path.get_directory(filepath)
-    go_mod_filepath = lib.find.file_upwards("go.mod", start_path)
-    local sysname = vim.uv.os_uname().sysname
-    local problematic_paths = {
-      Darwin = {
-        "/private/tmp",
-        "/tmp",
-        lib.path.normalize_path(vim.fn.expand("$HOME") .. "/Public"),
-      },
-      Linux = { "/tmp" },
-    }
-    if problematic_paths[sysname] == nil then
-      return
-    end
-    for _, problematic_path in ipairs(problematic_paths[sysname]) do
+    local go_mod_filepath = lib.find.file_upwards("go.mod", start_path)
+    for _, problematic_path in ipairs(problematic_paths) do
       if go_mod_filepath ~= nil and go_mod_filepath:find(problematic_path) then
         warn(
           "Path reportedly problematic: "


### PR DESCRIPTION
fixes `checkhealth` for windows system

issue:
```

==============================================================================
neotest-golang:                                                           1 ❌

System Information ~
- ✅ OK Operating System: Windows
- Version: 10.0.26200

Requirements ~
- ✅ OK Neovim version 0.12.3 is supported (>= 0.10.0)
- ✅ OK Binary 'go' found on PATH: C:\Users\Atif\scoop\shims\go.EXE
- ✅ OK Go version: go version go1.26.4 windows/amd64
- ✅ OK Found go.mod file for C:\Users\Atif\Projects\aiub-companion\internal\calendar\parser_test.go in C:\Users\Atif\Projects\aiub-companion\go.mod
- ❌ ERROR Failed to run healthcheck for "neotest-golang" plugin. Exception:
  ...m-data/lazy/neotest-golang/lua/neotest-golang/health.lua:98: attempt to concatenate a nil value
```



