### PR TITLE
fix(ci): pin neotest to pre-#607 commit to unbreak windows-nightly job

### DIFF
--- a/spec/bootstrap.lua
+++ b/spec/bootstrap.lua
@@ -15,6 +15,13 @@ local PLUGINS = {
   },
   neotest = {
     url = "https://github.com/nvim-neotest/neotest",
+    -- Pinned to the last commit before nvim-neotest/neotest#607 and #612
+    -- (merged 2026-07-02/03). Those commits correlate with the
+    -- nvim-test:nightly (windows-latest) CI failures that started between
+    -- the last green run (2026-07-01) and the first failing run
+    -- (2026-07-05). Unpin once the upstream regression is understood and
+    -- fixed.
+    hash = "ff5437f7d9af801917bed119082934b0eb6ee0e9",
   },
 }
 


### PR DESCRIPTION
## Why?

Most open PRs are currently failing CI. The failing job is always the same one: `nvim-test:nightly (windows-latest)` — every other job (including `nvim-test:stable (windows-latest)` and `nvim-test:nightly` on ubuntu/macos) passes.

Timeline:

- Last green `nvim-test:nightly (windows-latest)`: 2026-07-01 (e.g. #578, #572 on 2026-06-24)
- First failing run: 2026-07-05 (#580), still failing 2026-07-18 (#582)

The test environment clones its plugin dependencies at HEAD, so a moving upstream target is the prime suspect. Checking each dependency for commits in the regression window (2026-07-01 → 2026-07-05):

| Dependency | Commits in window? |
|---|---|
| nvim-treesitter (`main`) | No (latest: 2026-04-03) |
| plenary.nvim | No (latest: 2026-04-10) |
| nvim-nio | No (latest before 2026-07-15: 2025-01-20) |
| **neotest** | **Yes:** 639fb9e `fix(client/init): use adapter root as path for rtp` (#607, 2026-07-02) and e37147b `feat: remove plenary from runtime dependencies` (#612, 2026-07-03) |

Since `nvim-test:stable` passes on Windows with the same neotest master, the failure looks like an interaction between one of those two neotest changes and Neovim nightly on Windows (#607 touches path/rtp handling, which is platform-sensitive).

## Upstream references

- [nvim-neotest/neotest#623 — "[BUG] neotest-haskell freezes inside `resolve_plugin_root` function after e37147b"](https://github.com/nvim-neotest/neotest/issues/623) (open) — explicitly blames `e37147b` (our suspect #612); the failure is in `lib/subprocess.lua`'s `resolve_plugin_root()`, the same subprocess/adapter-root/rtp code path that #607 rewrote. No fix PR exists yet.
- [nvim-neotest/neotest#563 — "[BUG] No tests found on Windows"](https://github.com/nvim-neotest/neotest/issues/563) (open) — subprocess rtp set with mixed separators on Windows (`D:\...\share/nvim/runtime`); shows the Windows path handling in this code is already fragile.
- [nvim-neotest/neotest#510 — "Wrong path casing provided during initial test discovery"](https://github.com/nvim-neotest/neotest/issues/510) (closed) — earlier Windows path bug in the same area.
- [nvim-neotest/neotest#607](https://github.com/nvim-neotest/neotest/pull/607) / [nvim-neotest/neotest#612](https://github.com/nvim-neotest/neotest/pull/612) — the two suspect commits.
- On the Neovim side, [neovim/neovim#40689](https://github.com/neovim/neovim/issues/40689) (path-normalization change breaking plugins) is similar in spirit but landed ~2026-07-11, after our failures started, so it can't be the trigger — though it shows nightly's Windows path behavior is actively churning.

## What?

- Pin `neotest` to `ff5437f` (2026-06-30, the last commit before #607) in `spec/bootstrap.lua`, using the already-supported `hash` mechanism.
- This makes the CI run on this PR the experiment: if `nvim-test:nightly (windows-latest)` goes green here, the correlation is confirmed.

**Result: ✅ `nvim-test:nightly (windows-latest)` is green on this PR** (all other jobs pass too), confirming the correlation.

## Notes

- I could not read the failing job logs programmatically (GitHub requires sign-in for logs), so the exact failing spec/error is still unknown — the pin tested the strongest hypothesis from the timeline, and CI confirmed it.
- Next step: file an issue against nvim-neotest/neotest describing this Windows+nightly failure (linking #623), bisect #607 vs #612, and unpin once fixed upstream.
- Longer term, consider pinning all test plugin deps for hermetic CI; plenary.nvim is now archived and neotest master moves frequently.