### PR TITLE
chore: correct LuaLS workspace settings in .luarc.json

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -2,5 +2,5 @@
   "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
   "runtime.version": "LuaJIT",
   "workspace.checkThirdParty": false,
-  "workspace.ignoreDir": [".pocket", ".tests", ".venv", "site"]
+  "workspace.ignoreDir": [".vscode", ".pocket", ".tests", ".venv", "site"]
 }

--- a/.luarc.json
+++ b/.luarc.json
@@ -2,6 +2,5 @@
   "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
   "runtime.version": "LuaJIT",
   "workspace.checkThirdParty": false,
-  "workspace.ignoreDir": [".pocket/tools"],
-  "workspace.library": ["$VIMRUNTIME"]
+  "workspace.ignoreDir": [".pocket", ".tests", ".venv", "site"]
 }


### PR DESCRIPTION
## Why?

- [`.luarc.json`](https://github.com/fredrikaverpil/neotest-golang/blob/767b16aeb1cdad8747294c2861ae7547cc7dfcee/.luarc.json) takes precedence over settings sent by the LSP client, and it **replaces per key** rather than merging.
- `workspace.library` therefore wiped out whatever the client contributes — [lazydev.nvim](https://github.com/folke/lazydev.nvim), or an editor config that seeds the runtimepath itself — so [lua-language-server](https://github.com/LuaLS/lua-language-server) never loaded the [neotest](https://github.com/nvim-neotest/neotest) type definitions:

```
runspec/file.lua|12| Undefined type or alias `neotest.Position`
runspec/file.lua|15| Undefined type or alias `neotest.RunSpec`
```

- `workspace.ignoreDir` was too narrow. LuaLS reads only the **workspace-root** `.gitignore`, so `.pocket/tools` — ignored via `.pocket/.gitignore` — was indexed regardless: three complete Neovim distributions under `.pocket/tools/neovim/`, contributing ~11.6k symbols against ~60 from the project itself. Every `vim.*` lookup offered four candidates.
- `workspace.ignoreDir` replaces its own [documented default](https://github.com/LuaLS/lua-language-server/blob/master/doc/en-us/config.md) of `[".vscode"]` too, so listing only this project's directories silently un-ignores `.vscode` for contributors using VS Code.

## What?

- Drop `workspace.library`.
- Extend `workspace.ignoreDir` so exclusion does not depend on how a client handles gitignore, and re-list `.vscode` to preserve the default:

```json
"workspace.ignoreDir": [".vscode", ".pocket", ".tests", ".venv", "site"]
```

- Keep `runtime.version` and `workspace.checkThirdParty` — they conflict with nothing, and are the only source of those settings for contributors who do not configure `lua_ls` themselves.

## Notes

- The regression is narrow and the fix is not: contributors who seed no library of their own may now see ``Undefined global `vim` ``, since `workspace.library` was their only source of `$VIMRUNTIME`. ([nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) ships no `on_init` for `lua_ls` — the snippet in its docs is an example, not a default.) Keeping the key would trade that for total loss of type resolution for everyone whose client does send a library, [lazydev.nvim](https://github.com/folke/lazydev.nvim) users included — lazydev's health check flags a workspace `.luarc.json` for exactly this reason. The durable fix is to seed `workspace.library` in the editor config; it cannot be resolved from `.luarc.json` at all.
- `$VIMRUNTIME` was never dependable here regardless. It is an environment variable, expanded from the environment `lua_ls` inherits, so it only resolves when the server is spawned by Neovim — a contributor opening this repo in VS Code, or a `lua-language-server --check` run in CI, already got an empty library from it.
- Verified against [`lua/neotest-golang/runspec/dir.lua`](https://github.com/fredrikaverpil/neotest-golang/blob/767b16aeb1cdad8747294c2861ae7547cc7dfcee/lua/neotest-golang/runspec/dir.lua): references, `neotest.Position` and `vim.system` all resolve, and `.pocket`/`.tests` contribute 0 indexed symbols.
- Note for editors that seed `workspace.library` from the runtimepath: when this repo is checked out locally and added to the runtimepath, it becomes a *library* of that config's workspace, and this `.luarc.json` is never read. `ignoreDir` then has to be set editor-side — it does apply to library directories.

