### PR TITLE
feat: disable adapter when go is not on PATH

### DIFF
--- a/lua/neotest-golang/health.lua
+++ b/lua/neotest-golang/health.lua
@@ -16,7 +16,7 @@ function M.check()
 
   start("Requirements")
   M.neovim_version_check()
-  M.binary_found_on_path("go")
+  M.go_binary_found()
   M.go_version_check()
   M.go_mod_found()
   M.is_problematic_path()
@@ -66,6 +66,16 @@ function M.binary_found_on_path(executable, supress_warn)
     end
   end
   return false
+end
+
+--- The go binary is a hard requirement; without it, the adapter disables
+--- itself for any Go project found.
+function M.go_binary_found()
+  if vim.fn.executable("go") == 1 then
+    ok("Binary 'go' found on PATH: " .. vim.fn.exepath("go"))
+  else
+    error("Binary 'go' not found on PATH. The adapter is disabled without it.")
+  end
 end
 
 function M.go_mod_found()

--- a/lua/neotest-golang/init.lua
+++ b/lua/neotest-golang/init.lua
@@ -18,11 +18,23 @@ M.Adapter = {
   init = function() end,
 }
 
+--- Whether the Go toolchain is available. Without it, no tests can be
+--- executed, so the adapter disables itself. Reported by
+--- :checkhealth neotest-golang.
+--- @return boolean
+local function go_available()
+  return vim.fn.executable("go") == 1
+end
+
 --- Find root path for test suite.
 --- @async
 --- @param dir string @Directory to treat as cwd
 --- @return string | nil @Absolute root dir of test suite
 function M.Adapter.root(dir)
+  if not go_available() then
+    logger.debug("Binary 'go' not found on PATH, disabling adapter")
+    return nil
+  end
   return lib.find.root_for_tests(dir)
 end
 
@@ -83,6 +95,9 @@ end
 --- @param file_path string
 --- @return boolean
 function M.Adapter.is_test_file(file_path)
+  if not go_available() then
+    return false
+  end
   if lib.goenv.should_skip(file_path, vim.uv.cwd()) then
     return false
   end

--- a/spec/unit/is_test_file_spec.lua
+++ b/spec/unit/is_test_file_spec.lua
@@ -17,6 +17,21 @@ describe("Is test file", function()
     assert.is_false(adapter.is_test_file(file_path))
   end)
 
+  it("False - Go binary not on PATH", function()
+    local original_executable = vim.fn.executable
+    vim.fn.executable = function(name)
+      if name == "go" then
+        return 0
+      end
+      return original_executable(name)
+    end
+
+    local result = adapter.is_test_file("foo/bar/baz_test.go")
+
+    vim.fn.executable = original_executable
+    assert.is_false(result)
+  end)
+
   describe("Windows path handling", function()
     it("True - Windows path with backslashes", function()
       local file_path = "foo\\bar\\baz_test.go"

--- a/spec/unit/root_spec.lua
+++ b/spec/unit/root_spec.lua
@@ -1,0 +1,35 @@
+local _ = require("plenary")
+local adapter = require("neotest-golang")
+local find = require("neotest-golang.lib.find")
+
+describe("Root", function()
+  local project_root = vim.fn.getcwd()
+
+  before_each(function()
+    find.clear_root_cache()
+  end)
+
+  after_each(function()
+    find.clear_root_cache()
+  end)
+
+  it("returns the root of the Go project", function()
+    local root = adapter.root(project_root)
+    assert.equals(project_root, root)
+  end)
+
+  it("returns nil when the go binary is not on PATH", function()
+    local original_executable = vim.fn.executable
+    vim.fn.executable = function(name)
+      if name == "go" then
+        return 0
+      end
+      return original_executable(name)
+    end
+
+    local root = adapter.root(project_root)
+
+    vim.fn.executable = original_executable
+    assert.is_nil(root)
+  end)
+end)


### PR DESCRIPTION
## Why?

- Following #587, the adapter no longer throws when `go` is missing, but it still attaches itself to Go projects it cannot run tests in.
- Discovering tests which cannot be executed has little value, as raised in #586: the adapter should get out of the way, like it already does for projects which are not written in Go.
- Today, nothing states that intent in code. The adapter happens to stay out only as a side effect of [`should_skip()`](https://github.com/fredrikaverpil/neotest-golang/blob/b6f2e8165df34fdfe5b08f37bdd6f9fba3b3d16a/lua/neotest-golang/lib/goenv.lua#L90-L93) catching a thrown error. Should `vim.fn.system()` ever stop throwing for a binary which is not executable, the adapter would silently re-enable.

## What?

- Bail out of both adapter entry points when the `go` binary is not on PATH:

```lua
local function go_available()
  return vim.fn.executable("go") == 1
end
```

- [`root()`](https://github.com/fredrikaverpil/neotest-golang/blob/b6f2e8165df34fdfe5b08f37bdd6f9fba3b3d16a/lua/neotest-golang/init.lua#L31-L37) returns `nil` and [`is_test_file()`](https://github.com/fredrikaverpil/neotest-golang/blob/b6f2e8165df34fdfe5b08f37bdd6f9fba3b3d16a/lua/neotest-golang/init.lua#L98-L107) returns `false`.
- Report a missing `go` binary as an error instead of a warning in `:checkhealth neotest-golang`.
- Add specs for both entry points.

## Notes

- Both entry points need the check. [Neotest](https://github.com/nvim-neotest/neotest) registers an adapter either by root directory or by matching open buffers, and [the latter](https://github.com/nvim-neotest/neotest/blob/master/lua/neotest/client/init.lua#L544-L552) bypasses `root()` entirely, registering the adapter with `root = dir or cwd`.
- Nothing is notified to the user. Someone with the adapter enabled globally, working on a project which is not written in Go, is in the same situation and should not be interrupted either. `:checkhealth neotest-golang` is where this is explained.
- Not addressed here, spotted along the way: `gotestsum_installed_but_not_used()` reports OK when `gotestsum` is not on PATH, even when it is the configured `runner`.