### PR TITLE
perf: check test file suffix before the go env lookup

### DIFF
--- a/lua/neotest-golang/init.lua
+++ b/lua/neotest-golang/init.lua
@@ -95,13 +95,13 @@ end
 --- @param file_path string
 --- @return boolean
 function M.Adapter.is_test_file(file_path)
+  if not vim.endswith(file_path, "_test.go") then
+    return false
+  end
   if not go_available() then
     return false
   end
-  if lib.goenv.should_skip(file_path, vim.uv.cwd()) then
-    return false
-  end
-  return vim.endswith(file_path, "_test.go")
+  return not lib.goenv.should_skip(file_path, vim.uv.cwd())
 end
 
 --- Given a file path, parse all the tests within it.


### PR DESCRIPTION
## Why?

- [Neotest](https://github.com/nvim-neotest/neotest) asks every configured adapter whether a path is a test file, for every buffer it probes.
- `is_test_file()` answered that by first calling [`should_skip()`](https://github.com/fredrikaverpil/neotest-golang/blob/0d12a6114abbc1e0d8e7c5eb1f6c8ab5f1a3f4e0/lua/neotest-golang/lib/goenv.lua#L86-L99), which populates the GOPATH/GOROOT cache by running `go env`.
- A project without a single Go file therefore spawned a `go env` subprocess, from a `BufAdd` autocmd, to answer a question the filename suffix settles for free.

## What?

- Check the suffix first, so the go env lookup and the path normalization only happen for `*_test.go` paths:

```lua
function M.Adapter.is_test_file(file_path)
  if not vim.endswith(file_path, "_test.go") then
    return false
  end
  if not go_available() then
    return false
  end
  return not lib.goenv.should_skip(file_path, vim.uv.cwd())
end
```

## Notes

- Pure reordering. The outcome is unchanged: a path is a test file when the suffix matches, the go binary is available, and the path is not to be skipped. Covered by the existing `is_test_file` specs.